### PR TITLE
In g3frame_python_put, promote G3Int from int64_t rather than int.

### DIFF
--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -80,8 +80,8 @@ static void g3frame_python_put(G3Frame &f, std::string name, bp::object obj)
 		f.Put(name, bp::extract<G3FrameObjectPtr>(obj)());
 	else if (PyBool_Check(obj.ptr()))
 		f.Put(name, boost::make_shared<G3Bool>(bp::extract<bool>(obj)()));
-	else if (bp::extract<int>(obj).check())
-		f.Put(name, boost::make_shared<G3Int>(bp::extract<int>(obj)()));
+	else if (bp::extract<int64_t>(obj).check())
+		f.Put(name, boost::make_shared<G3Int>(bp::extract<int64_t>(obj)()));
 	else if (bp::extract<double>(obj).check())
 		f.Put(name, boost::make_shared<G3Double>(bp::extract<double>(obj)()));
 	else if (bp::extract<std::string>(obj).check())


### PR DESCRIPTION
This allows any standard python integer to be auto-loaded into a G3Frame slot.  Otherwise it's limited to 32-bit integers.

Example:
```
from spt3g import core
f = core.G3Frame()
f['large_integer'] = (1<<32)
```
Without the fix, this fails with "OverflowError: bad numeric conversion: positive overflow" originating from boost::python.