### PR TITLE
Add a warning message to help debug a certain boost issue.

### DIFF
--- a/core/include/core/std_map_indexing_suite.hpp
+++ b/core/include/core/std_map_indexing_suite.hpp
@@ -466,7 +466,12 @@ return incref(tuple.attr("__iter__")().ptr());
             std::string cl_name;
             object class_name(cl.attr("__name__"));
             extract<std::string> class_name_extractor(class_name);
-            cl_name = class_name_extractor();
+
+	    if (!class_name_extractor.check())
+	        std::cerr << __FILE__ << ":" << __LINE__ << ": object name "
+		    "extractor failed; import error imminent.\n" << std::flush;
+	    cl_name = class_name_extractor();
+
             elem_name += cl_name;
             elem_name += "_entry";
 

--- a/core/include/core/std_map_indexing_suite.hpp
+++ b/core/include/core/std_map_indexing_suite.hpp
@@ -468,8 +468,7 @@ return incref(tuple.attr("__iter__")().ptr());
             extract<std::string> class_name_extractor(class_name);
 
 	    if (!class_name_extractor.check())
-	        std::cerr << __FILE__ << ":" << __LINE__ << ": object name "
-		    "extractor failed; import error imminent.\n" << std::flush;
+  	        log_fatal("object.__name__ extractor failed; import error imminent.");
 	    cl_name = class_name_extractor();
 
             elem_name += cl_name;


### PR DESCRIPTION
The failure was observed in a conda installation; __name__ would not
extract to string.  This built ok but import failed with uninformative
SystemError.