### PR TITLE
Automatically store configuration and VCS information in all output data.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(core SHARED
 	src/G3TriggeredBuilder.cxx src/G3MultiFileWriter.cxx src/dataio.cxx
 	src/G3SkyMap.cxx src/crc32.c ${CORE_EXTRA_SRCS}
 	src/G3NetworkSender.cxx src/G3SyslogLogger.cxx
+	src/G3PipelineInfo.cxx
 )
 target_link_libraries(core pthread ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${FLAC_LIBRARIES})
 link_python_dir()

--- a/core/include/core/G3PipelineInfo.h
+++ b/core/include/core/G3PipelineInfo.h
@@ -14,6 +14,11 @@ public:
 
         template <class A> void load(A &ar, unsigned v);
         template <class A> void save(A &ar, unsigned v) const;
+
+	std::string Description() const;
+	std::string Summary() const;
+
+	bool operator ==(const G3ModuleConfig &) const;
 };
 
 class G3PipelineInfo : public G3FrameObject {
@@ -32,8 +37,8 @@ public:
 
 	template <class A> void serialize(A &ar, unsigned v);
 
-	std::string Description() const { return "Bork"; };
-	std::string Summary() const { return Description(); };
+	std::string Description() const;
+	std::string Summary() const;
 };
 
 G3_POINTERS(G3PipelineInfo);

--- a/core/include/core/G3PipelineInfo.h
+++ b/core/include/core/G3PipelineInfo.h
@@ -1,0 +1,49 @@
+#ifndef _G3_PIPELINEINFO_H
+#define _G3_PIPELINEINFO_H
+
+#include <G3Frame.h>
+#include <vector>
+#include <map>
+
+class G3ModuleConfig : public G3FrameObject {
+public:
+	std::string modname;
+	std::string instancename;
+
+	std::map<std::string, boost::python::object> config;
+
+        template <class A> void load(A &ar, unsigned v);
+        template <class A> void save(A &ar, unsigned v) const;
+};
+
+class G3PipelineInfo : public G3FrameObject {
+public:
+	std::string vcs_url;
+	std::string vcs_branch;
+	std::string vcs_revision;
+	bool vcs_localdiffs;
+	std::string vcs_versionname;
+	std::string vcs_githash; // If available
+
+	std::string hostname;
+	std::string user;
+
+	std::vector<G3ModuleConfig> modules;
+
+	template <class A> void serialize(A &ar, unsigned v);
+
+	std::string Description() const { return "Bork"; };
+	std::string Summary() const { return Description(); };
+};
+
+G3_POINTERS(G3PipelineInfo);
+
+namespace cereal {
+        template <class A> struct specialize<A, G3ModuleConfig, cereal::specialization::member_load_save> {};
+}
+
+G3_SERIALIZABLE(G3ModuleConfig, 1);
+G3_SERIALIZABLE(G3PipelineInfo, 1);
+
+#endif
+

--- a/core/python/modconstruct.py
+++ b/core/python/modconstruct.py
@@ -1,4 +1,4 @@
-from spt3g.core import G3Module, G3Pipeline, log_fatal
+from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal
 try:
     from spt3g.core import multiprocess
     multiproc_avail = True
@@ -120,7 +120,38 @@ def build_pymodule(pycallable, *args, **kwargs):
 
     return PyCallObjModule()
 
-def PipelineAddCallable(self, callable, name=None, subprocess=False, *args, **kwargs):
+class _add_pipeline_info(G3Module):
+    def __init__(self):
+        from spt3g import __version__ as version
+        import socket, getpass
+
+        G3Module.__init__(self)
+        self.infoemitted = False
+        self.pipelineinfo = G3PipelineInfo()
+        self.pipelineinfo.vcs_url = version.upstream_url
+        self.pipelineinfo.vcs_branch = version.upstream_branch
+        self.pipelineinfo.vcs_revision = version.revision
+        self.pipelineinfo.vcs_localdiffs = version.localdiffs
+        self.pipelineinfo.vcs_versionname = version.versionname
+        self.pipelineinfo.vcs_githash = version.gitrevision
+
+        self.pipelineinfo.hostname = socket.gethostname()
+        self.pipelineinfo.user = getpass.getuser()
+    def Process(self, fr):
+        if self.infoemitted:
+            return fr
+
+        import time
+        self.infoemitted = True
+        if fr.type == G3FrameType.PipelineInfo:
+            fr[str(G3Time.Now())] = self.pipelineinfo
+            return fr
+        else:
+            f = G3Frame(G3FrameType.PipelineInfo)
+            f[str(G3Time.Now())] = self.pipelineinfo
+            return [f, fr]
+
+def PipelineAddCallable(self, callable, name=None, subprocess=False, **kwargs):
     '''
     Add a processing module to the pipeline. It can be any subclass of
     spt3g.core.G3Module or any Python callable, either an instance or
@@ -130,17 +161,31 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, *args, **kw
     run in a separate process.
     '''
 
+    addpipelineinfo = False
+    if not hasattr(self, '_pipelineinfo'):
+        self._pipelineinfo = _add_pipeline_info()
+        addpipelineinfo = True
+
     if not hasattr(self, 'nameprefix'):
         self.nameprefix = ''
+    if (hasattr(callable, '__name__')):
+        callable_name = callable.__name__
+    elif (hasattr(callable, '__class__')):
+        callable_name = callable.__class__.__name__
+    else:
+        raise RuntimeError("Cannot establish name of pipeline module")
     if name is None:
-        if (hasattr(callable, '__name__')):
-            callable_name = callable.__name__
-        elif (hasattr(callable, '__class__')):
-            callable_name = callable.__class__.__name__
-        else:
-            raise RuntimeError("Cannot establish name of pipeline module")
         name = '%s.%s' % (callable.__module__, callable_name)
     name = self.nameprefix + name
+
+    # Record module configuration for root objects
+    if self.nameprefix == '': 
+        modconfig = G3ModuleConfig()
+        modconfig.instancename = name
+        modconfig.modname = '%s.%s' % (callable.__module__, callable_name)
+        for k,v in kwargs.items():
+            modconfig.config[k] = v
+        self._pipelineinfo.pipelineinfo.modules.append(modconfig)
 
     # Deal with the segment case
     if hasattr(callable, '__pipesegment__'):
@@ -148,18 +193,22 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, *args, **kw
         oldnameprefix = self.nameprefix
         self.nameprefix = name + '/'
 
-        rv = callable(self, *args, **kwargs)
+        rv = callable(self, **kwargs)
 
         self.nameprefix = oldnameprefix
-        return rv
 
     # Otherwise it's a module
-    if subprocess:
+    elif subprocess:
         if not multiproc_avail:
             raise ImportError('Multiprocess not available')
-        return self._Add_(build_pymodule(multiprocess.Subproc(build_pymodule(callable, *args, **kwargs), name=name)), name=name)
+        rv = self._Add_(build_pymodule(multiprocess.Subproc(build_pymodule(callable, **kwargs), name=name)), name=name)
     else:
-        return self._Add_(build_pymodule(callable, *args, **kwargs), name=name)
+        rv = self._Add_(build_pymodule(callable, **kwargs), name=name)
+
+    if addpipelineinfo:
+        self._Add_(self._pipelineinfo, name='_pipelineinfo')
+
+    return rv
 
 # Add this as G3Pipeline's Add method so it takes any Python callable
 G3Pipeline.Add = PipelineAddCallable

--- a/core/python/modconstruct.py
+++ b/core/python/modconstruct.py
@@ -212,4 +212,5 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, **kwargs):
 
 # Add this as G3Pipeline's Add method so it takes any Python callable
 G3Pipeline.Add = PipelineAddCallable
+G3Pipeline.__repr__ = lambda self: repr(self._pipelineinfo.pipelineinfo) if hasattr(self, '_pipelineinfo') else 'pipe = spt3g.core.G3Pipeline()'
 

--- a/core/src/G3PipelineInfo.cxx
+++ b/core/src/G3PipelineInfo.cxx
@@ -71,6 +71,7 @@ template <class A> void G3ModuleConfig::load(A &ar, unsigned v)
 				obj = bp::eval(bp::str(repr), global, global);
 			} catch (const bp::error_already_set& e) {
 				obj = bp::object(repr);
+				PyErr_Clear();
 			}
 			config[key] = obj;
 		}

--- a/core/src/G3PipelineInfo.cxx
+++ b/core/src/G3PipelineInfo.cxx
@@ -1,0 +1,129 @@
+#include <pybindings.h>
+#include <serialization.h>
+#include <G3PipelineInfo.h>
+#include <std_map_indexing_suite.hpp>
+
+#include <cereal/types/map.hpp>
+#include <cereal/types/vector.hpp>
+
+template <class A> void G3ModuleConfig::save(A &ar, unsigned v) const
+{
+	namespace bp = boost::python;
+
+	ar & cereal::make_nvp("G3FrameObject",
+	    cereal::base_class<G3FrameObject>(this));
+	ar & cereal::make_nvp("modname", modname);
+	ar & cereal::make_nvp("instancename", instancename);
+
+	ar << cereal::make_nvp("size", config.size());
+
+	for (auto i : config) {
+		ar << cereal::make_nvp("key", i.first);
+		
+		// Serialize frame objects (e.g. skymaps used as configs)
+		// directly. Serialize random python things through repr().
+		if (bp::extract<G3FrameObject>(i.second).check()) {
+			G3FrameObjectConstPtr fo =
+			    bp::extract<G3FrameObjectConstPtr>(i.second)();
+			ar << cereal::make_nvp("frameobject", true);
+			ar << cereal::make_nvp("value", fo);
+		} else {
+			std::string repr = bp::extract<std::string>(
+			    i.second.attr("__repr__")());
+			ar << cereal::make_nvp("frameobject", false);
+			ar << cereal::make_nvp("value", repr);
+		}
+	}
+}
+
+template <class A> void G3ModuleConfig::load(A &ar, unsigned v)
+{
+	namespace bp = boost::python;
+	bp::object main = bp::import("__main__");
+	bp::object global = main.attr("__dict__");
+
+	ar & cereal::make_nvp("G3FrameObject",
+	    cereal::base_class<G3FrameObject>(this));
+	ar & cereal::make_nvp("modname", modname);
+	ar & cereal::make_nvp("instancename", instancename);
+
+	size_t size;
+	ar >> cereal::make_nvp("size", size);
+
+	for (size_t i = 0; i < size; i++) {
+		std::string key;
+		bool is_frameobject;
+		ar >> cereal::make_nvp("key", key);
+		ar >> cereal::make_nvp("frameobject", is_frameobject);
+		
+		// Frame objects (e.g. skymaps used as configs) serialized
+		// directly. Random python things serialized as repr(), so
+		// eval() them.
+		if (is_frameobject) {
+			G3FrameObjectPtr fo;
+			ar >> cereal::make_nvp("value", fo);
+			config[key] = boost::python::object(fo);
+		} else {
+			std::string repr;
+			ar >> cereal::make_nvp("value", repr);
+			bp::object obj;
+			try {
+				obj = bp::eval(bp::str(repr), global, global);
+			} catch (const bp::error_already_set& e) {
+				obj = bp::object(repr);
+			}
+			config[key] = obj;
+		}
+	}
+}
+
+template <class A> void G3PipelineInfo::serialize(A &ar, unsigned v)
+{
+	using namespace cereal;
+
+	ar & make_nvp("G3FrameObject", base_class<G3FrameObject>(this));
+
+	ar & make_nvp("vcs_url", vcs_url);
+	ar & make_nvp("vcs_branch", vcs_branch);
+	ar & make_nvp("vcs_revision", vcs_revision);
+	ar & make_nvp("vcs_localdiffs", vcs_localdiffs);
+	ar & make_nvp("vcs_versionname", vcs_versionname);
+	ar & make_nvp("vcs_githash", vcs_githash);
+
+	ar & make_nvp("hostname", hostname);
+	ar & make_nvp("user", user);
+
+	ar & make_nvp("modules", modules);
+}
+
+G3_SPLIT_SERIALIZABLE_CODE(G3ModuleConfig);
+G3_SERIALIZABLE_CODE(G3PipelineInfo);
+
+PYBINDINGS("core") {
+	namespace bp = boost::python;
+
+	register_map<std::map<std::string, boost::python::object> >(
+	    "StringObjectMap", "Configuration options for a module");
+
+	EXPORT_FRAMEOBJECT(G3ModuleConfig, init<>(), "Stored configuration of a pipeline module or segment")
+	    .def_readwrite("modname", &G3ModuleConfig::modname)
+	    .def_readwrite("instancename", &G3ModuleConfig::instancename)
+	    .def_readwrite("config", &G3ModuleConfig::config)
+	;
+	register_pointer_conversions<G3ModuleConfig>();
+	//register_vector_of<G3ModuleConfig>("VectorStringObjectMap");
+
+	EXPORT_FRAMEOBJECT(G3PipelineInfo, init<>(), "Stored configuration of a pipeline, including software version information")
+	    .def_readwrite("vcs_url", &G3PipelineInfo::vcs_url)
+	    .def_readwrite("vcs_branch", &G3PipelineInfo::vcs_branch)
+	    .def_readwrite("vcs_revision", &G3PipelineInfo::vcs_revision)
+	    .def_readwrite("vcs_localdiffs", &G3PipelineInfo::vcs_localdiffs)
+	    .def_readwrite("vcs_versionname", &G3PipelineInfo::vcs_versionname)
+	    .def_readwrite("vcs_githash", &G3PipelineInfo::vcs_githash)
+	    .def_readwrite("hostname", &G3PipelineInfo::hostname)
+	    .def_readwrite("user", &G3PipelineInfo::user)
+	    .def_readwrite("modules", &G3PipelineInfo::modules)
+	;
+	register_pointer_conversions<G3PipelineInfo>();
+}
+

--- a/core/tests/compressedfileio.py
+++ b/core/tests/compressedfileio.py
@@ -9,6 +9,8 @@ pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
 n = 0
 def addinfo(fr):
 	global n
+	if fr.type != core.G3FrameType.Timepoint:
+		return
 	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
 	fr['count'] = n
 	n += 1
@@ -25,7 +27,7 @@ pipe.Add(core.Dump)
 n = 0
 def checkinfo(fr):
 	global n
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	if 'time' not in fr:
 		print('No time key in frame')

--- a/core/tests/cuts.py
+++ b/core/tests/cuts.py
@@ -9,14 +9,16 @@ pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
 n = 0
 def addinfo(fr):
 	global n
+	if fr.type != core.G3FrameType.Timepoint:
+		return
 	fr['count'] = n
 	n += 1
 pipe.Add(addinfo)
-pipe.Add(lambda frame: frame['count'] > 5)
+pipe.Add(lambda frame: 'count' in frame and frame['count'] > 5)
 pipe.Add(core.Dump)
 ids = []
 def getids(fr):
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	ids.append(fr['count'])
 pipe.Add(getids)

--- a/core/tests/deduplicate.py
+++ b/core/tests/deduplicate.py
@@ -42,7 +42,7 @@ pipe.Add(framesource)
 pipe.Add(core.DeduplicateMetadata)
 
 def getframes(fr):
-	if fr.type != core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.EndProcessing and fr.type != core.G3FrameType.PipelineInfo:
 		out.append(fr)
 pipe.Add(getframes)
 

--- a/core/tests/droporphanmetadata.py
+++ b/core/tests/droporphanmetadata.py
@@ -28,7 +28,7 @@ pipe.Add(framesource)
 pipe.Add(core.DropOrphanMetadata)
 
 def getframes(fr):
-	if fr.type != G3FrameType.EndProcessing:
+	if fr.type != G3FrameType.EndProcessing and fr.type != G3FrameType.PipelineInfo:
 		out.append(fr)
 pipe.Add(getframes)
 

--- a/core/tests/fileio.py
+++ b/core/tests/fileio.py
@@ -9,6 +9,8 @@ pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
 n = 0
 def addinfo(fr):
 	global n
+	if fr.type != core.G3FrameType.Timepoint:
+		return
 	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
 	fr['count'] = n
 	n += 1
@@ -25,7 +27,7 @@ pipe.Add(core.Dump)
 n = 0
 def checkinfo(fr):
 	global n
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	if 'time' not in fr:
 		print('No time key in frame')

--- a/core/tests/multifileio.py
+++ b/core/tests/multifileio.py
@@ -19,6 +19,7 @@ def addinfo(fr):
 	fr['count'] = n
 	n += 1
 pipe.Add(addinfo)
+pipe.Add(lambda fr: fr.type != core.G3FrameType.PipelineInfo) # Avoid extra frames that complicate accounting
 pipe.Add(core.G3MultiFileWriter, filename='multitest-%02u.g3', size_limit=20*1024)
 pipe.Add(core.G3MultiFileWriter, filename=lambda frame,seq: 'multitest2-%02d.g3' % seq, size_limit=20*1024)
 pipe.Add(core.G3MultiFileWriter, filename='multitest3-%02u.g3', size_limit=20*1024, divide_on=[core.G3FrameType.Timepoint])

--- a/core/tests/multiproc.py
+++ b/core/tests/multiproc.py
@@ -7,7 +7,7 @@ import time, sys
 n = 0
 def addinfo(fr):
 	global n
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
 	fr['count'] = n
@@ -15,7 +15,7 @@ def addinfo(fr):
 m = 0
 def checkinfo(fr):
 	global m
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	if 'time' not in fr:
 		print('No time key in frame')

--- a/core/tests/splitfileio.py
+++ b/core/tests/splitfileio.py
@@ -8,7 +8,7 @@ pipe = core.G3Pipeline()
 pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
 n = 0
 def addinfo(fr):
-	if fr.type == core.G3FrameType.EndProcessing:
+	if fr.type != core.G3FrameType.Timepoint:
 		return
 	global n
 	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))

--- a/doc/frames.rst
+++ b/doc/frames.rst
@@ -37,6 +37,17 @@ CalibratorOn		G3Timestream		Timestream of the calibrator sync signal. Set to 1 i
 GCPFeatureBits		G3VectorString		Strings describing the GCP flags field.
 ===================	====================	===========
 
+PipelineInfo
+============
+
+PipelineInfo frames contain information on the processing applied to make the remainder of the data. They typically occur at the beginning of the data stream and are automatically inserted by G3Pipeline, if not previously present. The frame will contain at least one element of type G3PipelineInfo that gives information on the version of the software that made the data and the configuration of all modules and/or segments added to the pipeline. Other data (G3PipelineInfo from previous scripts, configuration information added by other modules) may also be present.
+
+===================			===============	===========
+Key					Type		Description
+===================			===============	===========
+22-May-2019:18:42:15.335969000		G3PipelineInfo	Configuration information of the pipeline that produced an object. Added automatically. The key name is a timestamp indicating the time at which the software began running.
+===================			===============	===========
+
 Timepoint
 =========
 

--- a/doc/frames.rst
+++ b/doc/frames.rst
@@ -42,11 +42,11 @@ PipelineInfo
 
 PipelineInfo frames contain information on the processing applied to make the remainder of the data. They typically occur at the beginning of the data stream and are automatically inserted by G3Pipeline, if not previously present. The frame will contain at least one element of type G3PipelineInfo that gives information on the version of the software that made the data and the configuration of all modules and/or segments added to the pipeline. Other data (G3PipelineInfo from previous scripts, configuration information added by other modules) may also be present.
 
-===================			===============	===========
+==============================		===============	===========
 Key					Type		Description
-===================			===============	===========
+==============================		===============	===========
 22-May-2019:18:42:15.335969000		G3PipelineInfo	Configuration information of the pipeline that produced an object. Added automatically. The key name is a timestamp indicating the time at which the software began running.
-===================			===============	===========
+==============================		===============	===========
 
 Timepoint
 =========

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -283,3 +283,22 @@ ____________
 
 The ``Run()`` method runs the pipeline until completion (see `The first module`_). It takes one optional keyword argument (``profile``). If set to ``True``, it will print out the amount of system and user time spent in that module during processing after completion.
 
+G3PipelineInfo
+--------------
+
+G3Pipeline will automatically insert information about its configuration into the data stream by internally emitting a PipelineInfo frame containing a timestamped G3PipelineInfo object with the following information:
+
+- Version control information (branch, revision number, source URL, version name if any, presence of local diffs, etc.) reflecting the software currently running.
+- The user and host running the software.
+- The configuration of all modules and/or segments added to the pipeline.
+
+This information is added immediately following the first added module or segment. If the first frame in the data stream at this point is already a PipelineInfo frame, the G3PipelineInfo object described above will be added to it; otherwise, a new PipelineInfo frame with the object is prepended to the data stream.
+
+Within some limits imposed by Python (related to lambda functions, most notably), calling ``repr()`` on a G3PipelineInfo object (or a G3Pipeline object) will yield an executable Python script reflecting the exact modules and configuration used to produce the data. To within the mentioned limitations, this script can be rerun to exactly reproduce stored data; it can also be inspected to learn the configuration of the data's source pipeline[s] and thus the processing that produced it.
+
+Limitations:
+
+- The content of functions defined inline in a script (either by ``def`` or ``lambda``), as opposed to functions defined in an imported Python module, will not appear in the output, though options will. Inline functions defined by ``def`` will at least give the name of the function.
+- Options passed to pre-instantiated modules will not be stored. Only options passed in ``pipe.Add()`` will be recorded. For example, ``pipe.Add(core.G3Reader, filename="test.g3")`` will fully record its arguments, but ``pipe.Add(core.G3Reader(filename="test.g3")`` will not. Prefer the syntax that records options unless you have a compelling reason to do something else.
+- A G3Pipeline created in C++ will not record configuration; only G3Pipelines created in Python will.
+

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -272,7 +272,7 @@ The ``Add()`` method adds a module to the pipeline immediately following the las
 	pipe = G3Pipeline()
 	pipe.Add(core.G3Reader, filename="test.g3")
 
-For pipeline segments, only the second syntax works. As a result, the second syntax is generally preferred, as it can be used uniformly for all objects that can be passed to ``Add()``.
+For pipeline segments, only the second syntax works. As a result, the second syntax is generally preferred, as it can be used uniformly for all objects that can be passed to ``Add()``. Additionally, only the first syntax will record configuration information (see G3PipelineInfo_).
 
 ``Add()`` accepts a special keyword argument (``name``) that can be used to set the name of a module or segment in the output of run profiling (see below). If unspecified, it defaults to the name of the class or function, with slashes indexing modules added by pipeline segments.
 
@@ -299,6 +299,6 @@ Within some limits imposed by Python (related to lambda functions, most notably)
 Limitations:
 
 - The content of functions defined inline in a script (either by ``def`` or ``lambda``), as opposed to functions defined in an imported Python module, will not appear in the output, though options will. Inline functions defined by ``def`` will at least give the name of the function.
-- Options passed to pre-instantiated modules will not be stored. Only options passed in ``pipe.Add()`` will be recorded. For example, ``pipe.Add(core.G3Reader, filename="test.g3")`` will fully record its arguments, but ``pipe.Add(core.G3Reader(filename="test.g3")`` will not. Prefer the syntax that records options unless you have a compelling reason to do something else.
+- Options passed to pre-instantiated modules will not be stored. Only options passed in ``pipe.Add()`` will be recorded. For example, ``pipe.Add(core.G3Reader, filename="test.g3")`` will fully record its arguments, but ``pipe.Add(core.G3Reader(filename="test.g3"))`` will not. Prefer the syntax that records options unless you have a compelling reason to do something else.
 - A G3Pipeline created in C++ will not record configuration; only G3Pipelines created in Python will.
 

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -272,7 +272,7 @@ The ``Add()`` method adds a module to the pipeline immediately following the las
 	pipe = G3Pipeline()
 	pipe.Add(core.G3Reader, filename="test.g3")
 
-For pipeline segments, only the second syntax works. As a result, the second syntax is generally preferred, as it can be used uniformly for all objects that can be passed to ``Add()``. Additionally, only the first syntax will record configuration information (see G3PipelineInfo_).
+For pipeline segments, only the second syntax works. As a result, the second syntax is generally preferred, as it can be used uniformly for all objects that can be passed to ``Add()``. Additionally, only the second syntax will record configuration information (see G3PipelineInfo_).
 
 ``Add()`` accepts a special keyword argument (``name``) that can be used to set the name of a module or segment in the output of run profiling (see below). If unspecified, it defaults to the name of the class or function, with slashes indexing modules added by pipeline segments.
 

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -284,7 +284,7 @@ ____________
 The ``Run()`` method runs the pipeline until completion (see `The first module`_). It takes one optional keyword argument (``profile``). If set to ``True``, it will print out the amount of system and user time spent in that module during processing after completion.
 
 G3PipelineInfo
---------------
+______________
 
 G3Pipeline will automatically insert information about its configuration into the data stream by internally emitting a PipelineInfo frame containing a timestamped G3PipelineInfo object with the following information:
 


### PR DESCRIPTION
This patch modifies G3Pipeline to unconditionally include a "PipelineInfo" frame in the output that records vital statistics about when and how the processing was done (VCS branch, URL, presence of local diffs, version, running user, running host name, time of run start) and the configuration of all modules in the pipeline. To within the existence of lambda functions and the like, repr() on a PipelineInfo object will rehydrate the pipeline configuration and provide a runnable version of the script that made the file.

Example output:

```
In [1]: from spt3g import core                                                  

In [2]: import spt3g                                                            

In [3]: f = core.G3File('test.g3').next()                                       

In [4]: print(f)                                                                
Frame (PipelineInfo) [
"22-May-2019:18:42:15.335969000" (spt3g.core.G3PipelineInfo) => pipelineinfo branch, local diffs
]

In [5]: print(f['22-May-2019:18:42:15.335969000'].Description())                
Branch: pipelineinfo, local diffs
URL: https://github.com/CMB-S4/spt3g_software/branches/pipelineinfo
Revision: 222M
Run by: nwhitehorn on helicon.physics.ucla.edu
4 modules


In [6]: print(repr(f['22-May-2019:18:42:15.335969000']))                        
pipe = spt3g.core.G3Pipeline()
pipe.Add(spt3g.core.G3InfiniteSource, n=10, type=spt3g.core.G3FrameType.Timepoint)
pipe.Add(__main__.addinfo)
pipe.Add(spt3g.core.util.Dump)
pipe.Add(spt3g.core.G3Writer, filename='test.g3')
```
