### PR TITLE
Added flush function to G3Writer

### DIFF
--- a/core/include/core/G3Writer.h
+++ b/core/include/core/G3Writer.h
@@ -14,6 +14,7 @@ public:
 
 	virtual ~G3Writer();
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
+	void Flush();
 private:
 	std::string filename_;
 	boost::iostreams::filtering_ostream stream_;

--- a/core/src/G3Writer.cxx
+++ b/core/src/G3Writer.cxx
@@ -42,10 +42,26 @@ out:
 	out.push_back(frame);
 }
 
-EXPORT_G3MODULE("core", G3Writer, (init<std::string, optional<std::vector<G3Frame::FrameType> > >((arg("filename"), arg("streams")))),
-    "Writes frames to disk. Frames will be written to the file specified by "
-    "filename. If filename ends in .gz, output will be compressed using gzip. "
-    "To write only some types of frames, pass a list of the desired frame "
-    "types to the second optional argument (streams). If no streams argument "
-    "is given, writes all types of frames.");
+void G3Writer::Flush()
+{
+    if (!stream_.strict_sync()){
+        printf("There was a problem flushing the stream...\n");
+    }
+}
 
+PYBINDINGS("core") {
+	using namespace boost::python;
+
+	// Instead of EXPORT_G3MODULE since there is an extra Flush function
+	class_<G3Writer, bases<G3Module>, boost::shared_ptr<G3Writer>,
+	    boost::noncopyable>("G3Writer",
+	      "Writes frames to disk. Frames will be written to the file specified by "
+          "filename. If filename ends in .gz, output will be compressed using gzip. "
+          "To write only some types of frames, pass a list of the desired frame "
+          "types to the second optional argument (streams). If no streams argument "
+          "is given, writes all types of frames.",
+        init<std::string, optional<std::vector<G3Frame::FrameType> > >((arg("filename"), arg("streams"))))
+        .def("Flush", &G3Writer::Flush)
+        .def_readonly("__g3module__", true)
+	;
+}


### PR DESCRIPTION
This PR is to add a Flush function to the G3Writer module, which will flush any unwritten frames to disk, so the updated file can be cleanly read out. I wasn't sure if there was a good way to add an extra function using `EXPORT_G3MODULE`, so I switched it to use `PYBINDINGS`, modeled after the G3Reader module. If there's a better way to do this I can change it.