### PR TITLE
G3Reader: support for setting socket timeout.

### DIFF
--- a/core/include/core/G3NetworkSender.h
+++ b/core/include/core/G3NetworkSender.h
@@ -12,6 +12,7 @@ public:
 	G3NetworkSender(std::string hostname, int port, int max_queue_size);
 	virtual ~G3NetworkSender();
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
+	void Close(void);
 private:
 	int fd_;
 	int max_queue_size_;

--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -9,8 +9,10 @@
 
 class G3Reader : public G3Module {
 public:
-	G3Reader(std::string filename, int n_frames_to_read = -1);
-	G3Reader(std::vector<std::string> filenames, int n_frames_to_read = -1);
+	G3Reader(std::string filename, int n_frames_to_read = -1,
+                 float timeout = -1.);
+	G3Reader(std::vector<std::string> filenames, int n_frames_to_read = -1,
+                 float timeout = -1.);
 
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
 
@@ -22,6 +24,7 @@ private:
 	boost::iostreams::filtering_istream stream_;
 	int n_frames_to_read_;
 	int n_frames_read_;
+	float timeout_;
 
 	SET_LOGGER("G3Reader");
 };

--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -9,7 +9,7 @@
 // read files from disk, and from network sockets
 
 void g3_istream_from_path(boost::iostreams::filtering_istream &stream,
-    const std::string &path);
+    const std::string &path, float timeout=-1.0);
 
 #endif
 

--- a/core/include/core/pybindings.h
+++ b/core/include/core/pybindings.h
@@ -211,15 +211,20 @@ public:
 	static void CallRegistrarsFor(const char *mod);
 };
 
-#define EXPORT_G3MODULE(mod, T, init, docstring) \
+#define EXPORT_G3MODULE_AND(mod, T, init, docstring, other_defs)   \
 	static void registerfunc##T() { \
 		using namespace boost::python; \
 		class_<T, bases<G3Module>, boost::shared_ptr<T>, \
 		  boost::noncopyable>(#T, docstring, init) \
 		    .def_readonly("__g3module__", true) \
+                other_defs \
 		; \
 	} \
 	static G3ModuleRegistrator register##T(mod, registerfunc##T);
+
+#define EXPORT_G3MODULE(mod, T, init, docstring) \
+    EXPORT_G3MODULE_AND(mod, T, init, docstring, )
+
 
 #define PYBINDINGS(mod) \
 	static void ___pybindings_registerfunc(); \

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -18,7 +18,7 @@
 
 void
 g3_istream_from_path(boost::iostreams::filtering_istream &stream,
-    const std::string &path)
+                     const std::string &path, float timeout)
 {
 	stream.reset();
 	if (boost::algorithm::ends_with(path, ".gz"))
@@ -118,6 +118,16 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 			if (fd == -1)
 				log_fatal("Could not connect to %s (%s)",
 				    path.c_str(), strerror(errno));
+
+                        if (timeout >= 0) {
+                                struct timeval tv;
+                                tv.tv_sec = (int)timeout;
+                                tv.tv_usec = (int)(1e6 * (timeout - tv.tv_sec));
+                                if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                                               (char *)&tv, sizeof(tv)) < 0)
+                                        log_fatal("Failed to set timeout on socket; errno=%i",
+                                                  errno);
+                        }
 
 			if (info != NULL)
 				freeaddrinfo(info);

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -18,7 +18,7 @@
 
 void
 g3_istream_from_path(boost::iostreams::filtering_istream &stream,
-                     const std::string &path, float timeout)
+    const std::string &path, float timeout)
 {
 	stream.reset();
 	if (boost::algorithm::ends_with(path, ".gz"))

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -308,7 +308,7 @@ BOOST_PYTHON_MODULE(core)
 	    .value("Calibration",     G3Frame::Calibration)
 	    .value("Wiring",          G3Frame::Wiring)
 	    .value("GcpSlow",         G3Frame::GcpSlow)
-	    .value("None",            G3Frame::None)
+	    .value("none",            G3Frame::None)
 	;
 	enum_none_converter::from_python<G3Frame::FrameType>();
 	register_vector_of<G3Frame::FrameType>("FrameType");


### PR DESCRIPTION
This isn't as useful as hoped, because the connection needs to be
closed if the timeout expires.  So you can't, for example, set
timeout=0 and include Process() calls in an event loop.  However, the
present solution is still usable in cases where you do not want to
hang on Process() indefinitely and when you are ok with needing to
reconnect the Reader if the timeout expires.

Full non-blocking behavior would be great to have but relies on
getting boost istream_filter to propagate WOULD_BLOCK as distinct from
EOF.  Although I haven't understood the boost stuff fully, one thing
to note is that io::file_descriptor_source definitely does not
check+propagate EAGAIN after calling read(fd).