### PR TITLE
Optimize the Healpix ringsparse representation in memory

### DIFF
--- a/coordinateutils/include/coordinateutils/HealpixSkyMap.h
+++ b/coordinateutils/include/coordinateutils/HealpixSkyMap.h
@@ -87,7 +87,7 @@ public:
 	bool IsRingSparse() const { return (ring_sparse_ != NULL); }
 	bool IsIndexedSparse() const { return (indexed_sparse_ != NULL); }
 
-	bool IsShiftRa() const { return shift_ra_; }
+	bool IsRaShifted() const { return shift_ra_; }
 	void SetShiftRa(bool shift);
 
 	class const_iterator {

--- a/coordinateutils/include/coordinateutils/HealpixSkyMap.h
+++ b/coordinateutils/include/coordinateutils/HealpixSkyMap.h
@@ -101,10 +101,12 @@ public:
 		const_iterator(const const_iterator &iter);
 
 		bool operator==(const const_iterator & other) const {
-			return (index_ == other.index_);
+			return map_.ring_sparse_ ? (j_ == other.j_ && k_ == other.k_) :
+			    index_ == other.index_;
 		}
 		bool operator!=(const const_iterator & other) const {
-			return (index_ != other.index_);
+			return map_.ring_sparse_ ? (j_ != other.j_ || k_ != other.k_) :
+			    index_ != other.index_;
 		}
 
 		reference operator*() { return value_; };

--- a/coordinateutils/include/coordinateutils/HealpixSkyMap.h
+++ b/coordinateutils/include/coordinateutils/HealpixSkyMap.h
@@ -30,8 +30,7 @@ public:
  	    bool is_nested = false,
 	    MapCoordReference coord_ref = MapCoordReference::Equatorial,
 	    G3Timestream::TimestreamUnits u = G3Timestream::Tcmb,
-	    G3SkyMap::MapPolType pol_type = MapPolType::None,
-	    bool shift_ra = false);
+	    G3SkyMap::MapPolType pol_type = MapPolType::None);
 
 	HealpixSkyMap();
 	HealpixSkyMap(const HealpixSkyMap& fm);

--- a/coordinateutils/include/coordinateutils/HealpixSkyMap.h
+++ b/coordinateutils/include/coordinateutils/HealpixSkyMap.h
@@ -21,7 +21,8 @@ public:
  	    bool is_nested = false,
 	    MapCoordReference coord_ref = MapCoordReference::Equatorial,
 	    G3Timestream::TimestreamUnits u = G3Timestream::Tcmb,
-	    G3SkyMap::MapPolType pol_type = MapPolType::None);
+	    G3SkyMap::MapPolType pol_type = MapPolType::None,
+	    bool shift_ra = false);
 
 	// Constructor from a numpy array
 	HealpixSkyMap(boost::python::object v,
@@ -29,7 +30,8 @@ public:
  	    bool is_nested = false,
 	    MapCoordReference coord_ref = MapCoordReference::Equatorial,
 	    G3Timestream::TimestreamUnits u = G3Timestream::Tcmb,
-	    G3SkyMap::MapPolType pol_type = MapPolType::None);
+	    G3SkyMap::MapPolType pol_type = MapPolType::None,
+	    bool shift_ra = false);
 
 	HealpixSkyMap();
 	HealpixSkyMap(const HealpixSkyMap& fm);
@@ -86,6 +88,9 @@ public:
 	bool IsRingSparse() const { return (ring_sparse_ != NULL); }
 	bool IsIndexedSparse() const { return (indexed_sparse_ != NULL); }
 
+	bool IsShiftRa() const { return shift_ra_; }
+	void SetShiftRa(bool shift);
+
 	class const_iterator {
 	public:
 		typedef std::pair<uint64_t, double> value_type;
@@ -130,6 +135,7 @@ private:
 	SparseMapData *ring_sparse_;
 	std::unordered_map<uint64_t, double> *indexed_sparse_;
 	map_info *ring_info_;
+	bool shift_ra_;
 
 	SET_LOGGER("HealpixSkyMap");
 };
@@ -140,7 +146,7 @@ namespace cereal {
   template <class A> struct specialize<A, HealpixSkyMap, cereal::specialization::member_load_save> {};
 }
 
-G3_SERIALIZABLE(HealpixSkyMap, 1);
+G3_SERIALIZABLE(HealpixSkyMap, 2);
 
 #endif //_COORDINATEUTILS_HEALPIXSKYMAP_H
 

--- a/coordinateutils/include/coordinateutils/chealpix.h
+++ b/coordinateutils/include/coordinateutils/chealpix.h
@@ -64,13 +64,15 @@ typedef struct {
   long nring;
   double fact1;
   double fact2;
+  int shift_phi;
   ring_info *rings;
 } map_info;
 
 
-map_info * init_map_info(size_t nside, int populate);
+map_info * init_map_info(size_t nside, int shift_phi, int populate);
 void free_map_info(map_info *minfo);
 int get_ring_index(map_info *minfo, long pix, long *iring, long *ringpix);
+int get_pixel_index(map_info *minfo, long iring, long ringpix, long *pix);
 int get_interp_weights(map_info *minfo, double theta, double phi,
                        long pix[4], double weight[4]);
 

--- a/coordinateutils/include/coordinateutils/chealpix.h
+++ b/coordinateutils/include/coordinateutils/chealpix.h
@@ -64,12 +64,13 @@ typedef struct {
   long nring;
   double fact1;
   double fact2;
+  int nest;
   int shift_phi;
   ring_info *rings;
 } map_info;
 
 
-map_info * init_map_info(size_t nside, int shift_phi, int populate);
+map_info * init_map_info(size_t nside, int nest, int shift_phi, int populate);
 void free_map_info(map_info *minfo);
 int get_ring_index(map_info *minfo, long pix, long *iring, long *ringpix);
 int get_pixel_index(map_info *minfo, long iring, long ringpix, long *pix);

--- a/coordinateutils/python/fitsio.py
+++ b/coordinateutils/python/fitsio.py
@@ -174,7 +174,15 @@ def load_skymap_fits(filename, hdu=None):
                     data = np.array(H.data[hcol], dtype=float).ravel()
 
                     if col == 'PIXEL' or (partial and cidx == 0):
-                        pix = np.array(data, dtype=int)
+                        pix = np.array(data, dtype=int).ravel()
+                        # check if the range in phi is tighter with a shift by 180 deg
+                        # if so, then set shift_ra = True for better memory use
+                        # with the (default) ring sparse representation
+                        import healpy as hp
+                        _, phi = hp.pix2ang(nside, pix)
+                        shift_ra = bool(np.ptp(phi) > np.ptp((phi + np.pi) % (2 * np.pi)))
+                        del phi
+                        map_opts.update(shift_ra=shift_ra)
                         continue
 
                     units = unit_dict.get(hdr.get('TUNIT{:d}'.format(cidx + 1), units), units)

--- a/coordinateutils/python/fitsio.py
+++ b/coordinateutils/python/fitsio.py
@@ -176,14 +176,6 @@ def load_skymap_fits(filename, hdu=None):
                     if col == 'PIXEL' or (partial and cidx == 0):
                         pix = np.array(data, dtype=int).ravel()
                         del data
-                        # check if the range in phi is tighter with a shift by 180 deg
-                        # if so, then set shift_ra = True for better memory use
-                        # with the (default) ring sparse representation
-                        import healpy as hp
-                        _, phi = hp.pix2ang(nside, pix)
-                        shift_ra = bool(np.ptp(phi) > np.ptp((phi + np.pi) % (2 * np.pi)))
-                        del phi
-                        map_opts.update(shift_ra=shift_ra)
                         continue
 
                     units = unit_dict.get(hdr.get('TUNIT{:d}'.format(cidx + 1), units), units)

--- a/coordinateutils/src/HealpixSkyMap.cxx
+++ b/coordinateutils/src/HealpixSkyMap.cxx
@@ -259,6 +259,8 @@ HealpixSkyMap::load(A &ar, unsigned v)
 
 	if (v > 1)
 		ar & make_nvp("shift_ra", shift_ra_);
+	else
+		shift_ra_ = false;
 
 	free_map_info(ring_info_);
 	ring_info_ = init_map_info(nside_, is_nested_, shift_ra_, 1);
@@ -1072,7 +1074,7 @@ PYBINDINGS("coordinateutils")
 	    .def(bp::init<>())
 	    .add_property("nside", &HealpixSkyMap::nside)
 	    .add_property("nested", &HealpixSkyMap::nested)
-	    .add_property("shift_ra", &HealpixSkyMap::IsShiftRa, HealpixSkyMap_setshiftra,
+	    .add_property("shift_ra", &HealpixSkyMap::IsRaShifted, HealpixSkyMap_setshiftra,
 		"True if the ringsparse representation of the map is stored "
 		"with the rings centered at ra = 0 deg, rather than ra = 180 deg. "
 		"This property can be changed only when the map is not in the "

--- a/coordinateutils/src/HealpixSkyMap.cxx
+++ b/coordinateutils/src/HealpixSkyMap.cxx
@@ -962,7 +962,7 @@ HealpixSkyMap_setdense(HealpixSkyMap &m, bool v)
 	if (v)
 		m.ConvertToDense();
 	else
-		m.ConvertToIndexedSparse();
+		m.ConvertToRingSparse();
 }
 
 static void

--- a/coordinateutils/src/HealpixSkyMap.cxx
+++ b/coordinateutils/src/HealpixSkyMap.cxx
@@ -961,8 +961,12 @@ HealpixSkyMap_setdense(HealpixSkyMap &m, bool v)
 {
 	if (v)
 		m.ConvertToDense();
-	else
-		m.ConvertToRingSparse();
+	else {
+		PyErr_SetString(PyExc_ValueError,
+		    "Cannot set dense to False. Set ringsparse or "
+		    "indexedsparse to True to convert from dense.");
+		throw boost::python::error_already_set();
+	}
 }
 
 static void
@@ -970,8 +974,12 @@ HealpixSkyMap_setringsparse(HealpixSkyMap &m, bool v)
 {
 	if (v)
 		m.ConvertToRingSparse();
-	else
-		m.ConvertToIndexedSparse();
+	else {
+		PyErr_SetString(PyExc_ValueError,
+		    "Cannot set ringsparse to False. Set indexedsparse or "
+		    "dense to True to convert from ringsparse.");
+		throw boost::python::error_already_set();
+	}
 }
 
 static void
@@ -979,8 +987,12 @@ HealpixSkyMap_setindexedsparse(HealpixSkyMap &m, bool v)
 {
 	if (v)
 		m.ConvertToIndexedSparse();
-	else
-		m.ConvertToRingSparse();
+	else {
+		PyErr_SetString(PyExc_ValueError,
+		    "Cannot set indexedsparse to False. Set ringsparse or "
+		    "dense to True to convert from indexedsparse.");
+		throw boost::python::error_already_set();
+	}
 }
 
 static boost::python::tuple

--- a/coordinateutils/src/get_interp_val.c
+++ b/coordinateutils/src/get_interp_val.c
@@ -83,7 +83,7 @@ void get_ring_info(map_info *minfo, long iring, long *startpix,
   shift_phi : if 1, center rings at phi = 0 instead of phi = pi
   populate : if 1, populate all ring parameters
 */
-map_info * init_map_info(size_t nside, int shift_phi, int populate) {
+map_info * init_map_info(size_t nside, int nest, int shift_phi, int populate) {
   map_info *minfo = malloc(sizeof(*minfo));
   int iring;
   minfo->nside = nside;
@@ -93,6 +93,7 @@ map_info * init_map_info(size_t nside, int shift_phi, int populate) {
   minfo->nring = 4 * minfo->nside;
   minfo->fact2 = 4. / minfo->npix;
   minfo->fact1 = (minfo->nside << 1) * minfo->fact2;
+  minfo->nest = nest;
   minfo->shift_phi = shift_phi;
 
   minfo->rings = calloc(minfo->nring, sizeof(ring_info));
@@ -123,6 +124,9 @@ int get_ring_index(map_info *minfo, long pix, long *iring, long *ringpix) {
   long npix = minfo->npix;
   long nside = minfo->nside;
   long nring = minfo->nring;
+
+  if (minfo->nest)
+    nest2ring(nside, pix, &pix);
 
   if (pix < 0 || pix >= npix)
     return -1;
@@ -162,6 +166,9 @@ int get_pixel_index(map_info *minfo, long iring, long ringpix, long *pix)
 
   if (*pix < 0 || *pix > minfo->npix)
     return -1;
+
+  if (minfo->nest)
+    ring2nest(minfo->nside, *pix, pix);
 
   return 0;
 }
@@ -260,6 +267,13 @@ int get_interp_weights(map_info *minfo, double theta, double phi,
     weight[3] *= wtheta;
   }
 
+  if (minfo->nest) {
+    ring2nest(nside, pix[0], pix + 0);
+    ring2nest(nside, pix[1], pix + 1);
+    ring2nest(nside, pix[2], pix + 2);
+    ring2nest(nside, pix[3], pix + 3);
+  }
+
   return 0;
 }
 
@@ -296,9 +310,9 @@ double get_interp_val(map_info *minfo, double *map,
   val : output array of interpolated values
   n : number of interpolation points
 */
-void get_interp_valn(int nside, double *map, double *theta, double *phi,
+void get_interp_valn(int nside, int nest, double *map, double *theta, double *phi,
                      double *val, int n) {
-  map_info *minfo = init_map_info(nside, 0, 0);
+  map_info *minfo = init_map_info(nside, nest, 0, 0);
   int ii;
   for (ii = 0; ii < n; ii++) {
     val[ii] = get_interp_val(minfo, map, theta[ii], phi[ii]);
@@ -328,7 +342,7 @@ int main(int argc, char *argv[]) {
 
 
   double val[100];
-  get_interp_valn(nside, map, theta, phi, val, 100);
+  get_interp_valn(nside, 0, map, theta, phi, val, 100);
 
   for (int ii = 0; ii < 100; ii ++) {
     printf("theta: %6f, phi: %6f, val: %6f\n", theta[ii], phi[ii], val[ii]);

--- a/coordinateutils/tests/healpix_maps.py
+++ b/coordinateutils/tests/healpix_maps.py
@@ -105,14 +105,14 @@ assert((numpy.asarray(x) == a).all())
 assert(x.dense) # Should be dense again
 
 # test ra shifting
-x.indexedsparse = True
-x.shift_ra = True
+x.shift_ra = False
+x.ringsparse = True
 ki, vi = x.nonzero_pixels()
 ii = numpy.argsort(ki)
 ki = numpy.asarray(ki)[ii]
 vi = numpy.asarray(vi)[ii]
 
-x.ringsparse == True
+x.shift_ra = True
 kr, vr = x.nonzero_pixels()
 ii = numpy.argsort(kr)
 kr = numpy.asarray(kr)[ii]
@@ -120,7 +120,6 @@ vr = numpy.asarray(vr)[ii]
 assert((ki == kr).all())
 assert((vi == vr).all())
 
-x.indexedsparse = True
 x.shift_ra = False
 ki, vi = x.nonzero_pixels()
 ii = numpy.argsort(ki)

--- a/coordinateutils/tests/healpix_maps.py
+++ b/coordinateutils/tests/healpix_maps.py
@@ -52,7 +52,7 @@ assert(numpy.sum(x2) == numpy.sum(v))
 x.shift_ra = True
 x.ringsparse = True # Indexed to ring
 assert(x.nside == 64)
-# assert(x.npix_allocated == 1500)
+assert(x.npix_allocated == 1512) # shifted ringsparse is less efficient
 assert(x[1499] == 1499)
 assert(x[1501] == 0)
 

--- a/coordinateutils/tests/healpix_maps.py
+++ b/coordinateutils/tests/healpix_maps.py
@@ -49,11 +49,20 @@ x2 = x.rebin(2, norm=False)
 assert(x2[0] == v0)
 assert(numpy.sum(x2) == numpy.sum(v))
 
+# x.shift_ra = True
 x.ringsparse = True # Indexed to ring
 assert(x.nside == 64)
 assert(x.npix_allocated == 1500)
 assert(x[1499] == 1499)
 assert(x[1501] == 0)
+
+k,v = x.nonzero_pixels()
+assert(len(k) == len(v) == 1500)
+assert(set(v) == set(a))
+
+x2 = x.rebin(2, norm=False)
+assert(x2[0] == v0)
+assert(numpy.sum(x2) == numpy.sum(v))
 
 x.dense = True # Ring to dense
 assert(x[1499] == 1499)
@@ -76,14 +85,6 @@ for i in range(1,1500):
 	assert(x[i] == i)
 assert(x[1501] == 0)
 
-k,v = x.nonzero_pixels()
-assert(len(k) == len(v) == 1500)
-assert(set(v) == set(a))
-
-x2 = x.rebin(2, norm=False)
-assert(x2[0] == v0)
-assert(numpy.sum(x2) == numpy.sum(v))
-
 # Initialization from dense arrays
 a = numpy.arange(49152)
 x = coordinateutils.HealpixSkyMap(a)
@@ -101,6 +102,32 @@ for i in range(0, len(a)):
 
 assert((numpy.asarray(x) == a).all())
 assert(x.dense) # Should be dense again
+
+# test ra shifting
+x.indexedsparse = True
+x.shift_ra = True
+ki, vi = x.nonzero_pixels()
+ii = numpy.argsort(ki)
+ki = numpy.asarray(ki)[ii]
+vi = numpy.asarray(vi)[ii]
+
+x.ringsparse == True
+kr, vr = x.nonzero_pixels()
+ii = numpy.argsort(kr)
+kr = numpy.asarray(kr)[ii]
+vr = numpy.asarray(vr)[ii]
+assert((ki == kr).all())
+assert((vi == vr).all())
+
+x.indexedsparse = True
+x.shift_ra = False
+ki, vi = x.nonzero_pixels()
+ii = numpy.argsort(ki)
+ki = numpy.asarray(ki)[ii]
+vi = numpy.asarray(vi)[ii]
+assert((ki == kr).all())
+assert((vi == vr).all())
+
 
 # Conversion to/from flatsky maps
 fm_stub = coordinateutils.FlatSkyMap(

--- a/coordinateutils/tests/healpix_maps.py
+++ b/coordinateutils/tests/healpix_maps.py
@@ -49,10 +49,10 @@ x2 = x.rebin(2, norm=False)
 assert(x2[0] == v0)
 assert(numpy.sum(x2) == numpy.sum(v))
 
-# x.shift_ra = True
+x.shift_ra = True
 x.ringsparse = True # Indexed to ring
 assert(x.nside == 64)
-assert(x.npix_allocated == 1500)
+# assert(x.npix_allocated == 1500)
 assert(x[1499] == 1499)
 assert(x[1501] == 0)
 
@@ -65,6 +65,7 @@ assert(x2[0] == v0)
 assert(numpy.sum(x2) == numpy.sum(v))
 
 x.dense = True # Ring to dense
+x.shift_ra = False
 assert(x[1499] == 1499)
 assert(x.npix_allocated == x.size)
 assert(len({x[i] for i in range(x.size) if x[i] != 0}) == 1500)

--- a/coordinateutils/tests/healpixskymap_operators.py
+++ b/coordinateutils/tests/healpixskymap_operators.py
@@ -7,21 +7,21 @@ from spt3g.coordinateutils import HealpixSkyMap
 # Simple in-place operators
 m = HealpixSkyMap(64)
 m[15] = 10
-assert(m.indexedsparse)
+assert(m.ringsparse)
 
 m *= 5
 m /= 25
 assert(m[15] == 2)
-assert(m.indexedsparse)
+assert(m.ringsparse)
 assert(m[16] == 0)
 
-assert((-m).indexedsparse)
+assert((-m).ringsparse)
 assert((-m)[15] == -2)
 
 m += 3
 m -=14
 assert(m[15] == -9)
-assert(not m.indexedsparse)
+assert(not m.ringsparse)
 assert(m[16] == -11)
 
 n = 1 - m


### PR DESCRIPTION
The default `ringsparse` representation divides the sphere into rings such that index 0 on a ring corresponds to ra = 0.  This is suboptimal for maps that are centered at ra = 0, like those collected at the South Pole.

This commit adds a boolean optional argument, `shift_ra`, that rearranges the `ringsparse` pixelization such that ring index 0 corresponds to ra = -180 degrees.  This argument defaults to `False`.  It is up to the user to set this option appropriately, either as an argument to the constructor or by setting the `shift_ra` attribute of an existing map object.  When reading in explicitly indexed HEALpix data (either from a fits file or creating a `HealpixSkyMap` instance from `numpy` arrays by hand), this argument is determined empirically from the distribution of input pixels in phi to optimize memory allocation.

For a map with typical South Pole coverage, this improves the memory footprint of the `ringsparse` representation by more than a factor of 2.

The default map representation for new maps or maps loaded from explicitly indexed fits files has also been changed from the `indexedsparse` representation to the `ringsparse` representation.  Finally, setting any of the representation properties to `False` now raises an error, since that is ill-defined behavior.