### PR TITLE
Improved CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 if(POLICY CMP0060) # Avoid cmake misfeature that can link the wrong libraries
 	cmake_policy(SET CMP0060 NEW)
 endif()
@@ -14,69 +14,30 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spt3g)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
 # Work around stupid broken Red Hat systems
 set(CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "")
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-	message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler (GCC > 4.7, Clang).")
-endif()
+# Require C++ 11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-warning-option -Wno-unused -Wno-unused-result -Wno-deprecated-register -Wno-sign-compare -Werror -Wno-constant-conversion -Wno-self-assign-overloaded -Wno-deprecated-declarations")
+# Compiler and include configurations
+set(SPT3G_SOURCE_DIR ${CMAKE_SOURCE_DIR})
+set(SPT3G_BUILD_DIR ${CMAKE_BINARY_DIR})
 
-# Fix bugs in GCC 4.4's strict aliasing code by turning it off
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Spt3gIncludes.cmake.in ${CMAKE_BINARY_DIR}/cmake/Spt3gIncludes.cmake @ONLY)
+include(${CMAKE_BINARY_DIR}/cmake/Spt3gIncludes.cmake)
 
-# Work around yet more bugs in GCC 4.4, this time with C++ 11 support
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_SMART_PTR=1")
-
-# Boost bits we need
-find_package(PythonInterp)
-find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-set(Boost_NO_BOOST_CMAKE ON)
-
-if(NOT DEFINED Boost_PYTHON_TYPE)
-	set(Boost_PYTHON_TYPE python)
-
-	# Detect attempts to be clever with the naming of the Boost Python library
-	string(REGEX REPLACE ".*libpython([0-9])\\.[0-9]+.*\\..*" "\\1" PYTHONMAJORVER ${PYTHON_LIBRARIES})
-	string(REGEX REPLACE ".*libpython[0-9]\\.([0-9]+).*\\..*" "\\1" PYTHONMINORVER ${PYTHON_LIBRARIES})
-
-	# Hack for some old Boost CMake modules
-	set(_Boost_PYTHON${PYTHONMAJORVER}_HEADERS "boost/python.hpp")
-	set(_Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_HEADERS "boost/python.hpp")
-
-	find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER}${PYTHONMINORVER})
-	if (${Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_FOUND})
-		set(Boost_PYTHON_TYPE python${PYTHONMAJORVER}${PYTHONMINORVER})
-	else()
-		find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER})
-		if (${Boost_PYTHON${PYTHONMAJORVER}_FOUND})
-			set(Boost_PYTHON_TYPE python${PYTHONMAJORVER})
-		endif()
-	endif()
-endif()
-
-find_package(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
-include_directories(${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_PATH})
-if(Boost_VERSION EQUAL 104700 OR Boost_VERSION GREATER 104700)
-	set(Boost_GEOMETRY_AVAIL ON)
-	message(STATUS "Boost Geometry Available")
-endif()
-
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SPT3G_LIBRARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SPT3G_RUNTIME_DIR})
 
 # Make python import more idiomatic
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
+
+# Raise errors on every warning by default
+# (use target-specific options to disable particular warnings)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 
 # Shell script to set environment variables
 configure_file(${CMAKE_SOURCE_DIR}/cmake/env-shell.sh.in ${CMAKE_BINARY_DIR}/env-shell.sh @ONLY)
@@ -86,48 +47,12 @@ execute_process(COMMAND mkdir -p ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 execute_process(COMMAND mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 execute_process(COMMAND ln -fsn ${CMAKE_SOURCE_DIR}/cmake/init.py ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/__init__.py)
 
-# Use cmake directory for packages
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{SITE_CMAKE_DIR} "${CMAKE_SOURCE_DIR}/cmake")
-
-# Frequently used external code
-set(OpenMP_FIND_QUIETLY TRUE)
-find_package(GSL)
-find_package(OpenMP)
-find_package(FFTW)
-find_package(HDF5)
-find_package(MPI)
-
-# Convenience macros
-macro(link_python_dir)
-	execute_process(COMMAND mkdir -p ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
-		execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/python ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PROJECT})
-	else(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
-		execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PROJECT})
-	endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
-endmacro(link_python_dir)
-macro(add_spt3g_test test_name)
-	add_test(${PROJECT}/${test_name} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/${test_name}.py)
-
-    set (extra_macro_args ${ARGN})
-    list(LENGTH extra_macro_args num_extra_args)
-    if (${num_extra_args} GREATER 0)
-        list(GET extra_macro_args 0 test_labels)
-		set_tests_properties(${PROJECT}/${test_name} PROPERTIES LABELS ${test_labels})
-    endif ()
-endmacro(add_spt3g_test test_name)
-
 # Find all sub-projects
 file(GLOB cmake_projects RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/*/CMakeLists.txt)
 foreach(d ${cmake_projects})
 	get_filename_component(proj ${d} PATH)
 	set(SUBDIRS ${SUBDIRS} ${proj})
-	get_filename_component(pname ${proj} NAME_WE)
-	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/${pname}/include)
 endforeach(d ${cmake_projects})
-
-# Make core includes available without directories
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/core/include/core)
 
 list(SORT SUBDIRS)
 foreach(subdir ${SUBDIRS})
@@ -135,7 +60,14 @@ foreach(subdir ${SUBDIRS})
 	message(STATUS "+ ${pname}")
 	set(PROJECT ${pname})
 	add_subdirectory(${CMAKE_SOURCE_DIR}/${pname})
+	if (TARGET ${pname})
+		set(SPT3G_LIBRARIES ${SPT3G_LIBRARIES} ${pname})
+	endif()
 endforeach(subdir ${SUBDIRS})
+
+# export configuration files for use in other projects
+export(TARGETS ${SPT3G_LIBRARIES} NAMESPACE spt3g:: FILE ${CMAKE_BINARY_DIR}/cmake/Spt3gTargets.cmake)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Spt3gConfig.cmake.in ${CMAKE_BINARY_DIR}/cmake/Spt3gConfig.cmake @ONLY)
 
 # Add fetching of test data
 add_custom_target(testdata COMMAND rsync -vrlpt --delete rsync://bolo.berkeley.edu/testdata ${CMAKE_BINARY_DIR}/testdata COMMENT "Rsyncing test data from bolo.berkeley.edu")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,58 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 # (use target-specific options to disable particular warnings)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 
+# Interface library for flags and library dependencies
+add_library(spt3g INTERFACE)
+
+# Ignore known warnings
+target_compile_options(spt3g INTERFACE -Wno-unknown-warning-option -Wno-unused -Wno-unused-result -Wno-deprecated-register -Wno-sign-compare -Wno-constant-conversion -Wno-self-assign-overloaded -Wno-deprecated-declarations)
+
+# Fix bugs in GCC 4.4's strict aliasing code by turning it off
+target_compile_options(spt3g INTERFACE -fno-strict-aliasing)
+
+# Boost bits we need
+find_package(PythonInterp)
+find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+set(Boost_NO_BOOST_CMAKE ON)
+
+if(NOT DEFINED Boost_PYTHON_TYPE)
+	set(Boost_PYTHON_TYPE python)
+
+	# Detect attempts to be clever with the naming of the Boost Python library
+	string(REGEX REPLACE ".*libpython([0-9])\\.[0-9]+.*\\..*" "\\1" PYTHONMAJORVER ${PYTHON_LIBRARIES})
+	string(REGEX REPLACE ".*libpython[0-9]\\.([0-9]+).*\\..*" "\\1" PYTHONMINORVER ${PYTHON_LIBRARIES})
+
+	# Hack for some old Boost CMake modules
+	set(_Boost_PYTHON${PYTHONMAJORVER}_HEADERS "boost/python.hpp")
+	set(_Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_HEADERS "boost/python.hpp")
+
+	find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER}${PYTHONMINORVER})
+	if (${Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_FOUND})
+		set(Boost_PYTHON_TYPE python${PYTHONMAJORVER}${PYTHONMINORVER})
+	else()
+		find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER})
+		if (${Boost_PYTHON${PYTHONMAJORVER}_FOUND})
+			set(Boost_PYTHON_TYPE python${PYTHONMAJORVER})
+		endif()
+	endif()
+endif()
+
+find_package(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
+if(Boost_VERSION EQUAL 104700 OR Boost_VERSION GREATER 104700)
+	set(Boost_GEOMETRY_AVAIL ON)
+	message(STATUS "Boost Geometry Available")
+endif()
+
+target_include_directories(spt3g INTERFACE ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_PATH})
+target_link_libraries(spt3g INTERFACE pthread ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+
+# Work around yet more bugs in GCC 4.4, this time with C++ 11 support
+target_compile_definitions(spt3g INTERFACE -DBOOST_NO_CXX11_SMART_PTR=1)
+
 # Shell script to set environment variables
 configure_file(${CMAKE_SOURCE_DIR}/cmake/env-shell.sh.in ${CMAKE_BINARY_DIR}/env-shell.sh @ONLY)
 
@@ -54,6 +106,7 @@ foreach(d ${cmake_projects})
 	set(SUBDIRS ${SUBDIRS} ${proj})
 endforeach(d ${cmake_projects})
 
+set(SPT3G_LIBRARIES spt3g)
 list(SORT SUBDIRS)
 foreach(subdir ${SUBDIRS})
 	get_filename_component(pname ${subdir} NAME_WE)

--- a/calibration/CMakeLists.txt
+++ b/calibration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(calibration SHARED
+add_spt3g_library(calibration SHARED
 	src/BoloProperties.cxx src/PointingProperties.cxx src/python.cxx
 )
 target_link_libraries(calibration core)

--- a/cmake/Spt3gConfig.cmake.in
+++ b/cmake/Spt3gConfig.cmake.in
@@ -1,0 +1,14 @@
+set(SPT3G_SOURCE_DIR @CMAKE_SOURCE_DIR@)
+set(SPT3G_BUILD_DIR @CMAKE_BINARY_DIR@)
+
+set(SPT3G_INCLUDE_DIRS ${SPT3G_SOURCE_DIR}/core/include/core)
+foreach(lib @SPT3G_LIBRARIES@)
+	set(SPT3G_LIBRARIES ${SPT3G_LIBRARIES} spt3g::${lib})
+	set(SPT3G_INCLUDE_DIRS ${SPT3G_SOURCE_DIR}/${lib}/include)
+endforeach(lib @SPT3G_LIBRARIES@)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${SPT3G_BUILD_DIR}/cmake)
+include(Spt3gIncludes)
+include(Spt3gTargets)
+
+set(SPT3G_FOUND true)

--- a/cmake/Spt3gIncludes.cmake.in
+++ b/cmake/Spt3gIncludes.cmake.in
@@ -1,0 +1,35 @@
+# Use cmake directory for packages
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{SITE_CMAKE_DIR} "${SPT3G_SOURCE_DIR}/cmake")
+
+# Convenience variables
+set(SPT3G_LIBRARY_DIR ${SPT3G_BUILD_DIR}/spt3g)
+set(SPT3G_RUNTIME_DIR ${SPT3G_BUILD_DIR}/bin)
+
+# Convenience macros
+macro(link_python_dir)
+	execute_process(COMMAND mkdir -p ${SPT3G_LIBRARY_DIR})
+	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
+		execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/python ${SPT3G_LIBRARY_DIR}/${PROJECT})
+	else(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
+		execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR} ${SPT3G_LIBRARY_DIR}/${PROJECT})
+	endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)
+endmacro(link_python_dir)
+
+macro(add_spt3g_library lib_name)
+	add_library(${lib_name} ${ARGN})
+	target_compile_features(${lib_name} PUBLIC cxx_std_11)
+	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+		target_include_directories(${lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+	endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endmacro(add_spt3g_library lib_name)
+
+macro(add_spt3g_test test_name)
+	add_test(${PROJECT}/${test_name} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/${test_name}.py)
+
+	set(extra_macro_args ${ARGN})
+	list(LENGTH extra_macro_args num_extra_args)
+	if (${num_extra_args} GREATER 0)
+		list(GET extra_macro_args 0 test_labels)
+		set_tests_properties(${PROJECT}/${test_name} PROPERTIES LABELS ${test_labels})
+	endif ()
+endmacro(add_spt3g_test test_name)

--- a/coordinateutils/CMakeLists.txt
+++ b/coordinateutils/CMakeLists.txt
@@ -1,10 +1,4 @@
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    add_definitions(-DOPENMP_FOUND)
-endif()
-
-add_library(coordinateutils SHARED
+add_spt3g_library(coordinateutils SHARED
   src/chealpix.c
   src/get_interp_val.c
   src/G3SkyMap.cxx
@@ -17,8 +11,16 @@ add_library(coordinateutils SHARED
   src/python.cxx
 )
 
+set(OpenMP_FIND_QUIETLY TRUE)
+find_package(OpenMP)
+if(OPENMP_FOUND)
+	target_compile_definitions(coordinateutils PUBLIC -DOPENMP_FOUND)
+	target_compile_options(coordinateutils PUBLIC ${OpenMP_CXX_FLAGS})
+endif()
+
 target_link_libraries(coordinateutils core)
-execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/python ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/coordinateutils)
+
+link_python_dir()
 
 add_spt3g_test(quatangtest)
 add_spt3g_test(transtest SLOWTEST)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,12 +1,3 @@
-find_package(FLAC)
-
-if(FLAC_FOUND)
-	add_definitions(-DG3_HAS_FLAC)
-	include_directories(${FLAC_INCLUDE_DIR})
-else()
-	set(FLAC_LIBRARIES "")
-endif()
-
 # OS X has a broken implementatin of pthreads.
 if(APPLE)
 	set(CORE_EXTRA_SRCS src/ApplePthreadBarrier.cxx)
@@ -14,7 +5,7 @@ else(APPLE)
 	set(CORE_EXTRA_SRCS "")
 endif(APPLE)
 
-add_library(core SHARED
+add_spt3g_library(core SHARED
 	src/G3EventBuilder.cxx src/G3Frame.cxx src/G3TimeStamp.cxx
 	src/G3Pipeline.cxx src/G3Writer.cxx src/G3Reader.cxx src/python.cxx
 	src/G3InfiniteSource.cxx src/G3Logging.cxx src/G3PrintfLogger.cxx
@@ -25,8 +16,69 @@ add_library(core SHARED
 	src/G3NetworkSender.cxx src/G3SyslogLogger.cxx
 	src/G3PipelineInfo.cxx src/G3Quat.cxx
 )
-target_link_libraries(core pthread ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${FLAC_LIBRARIES})
+
+# Ignore known warnings
+target_compile_options(core PUBLIC -Wno-unknown-warning-option -Wno-unused -Wno-unused-result -Wno-deprecated-register -Wno-sign-compare -Wno-constant-conversion -Wno-self-assign-overloaded -Wno-deprecated-declarations)
+
+# Fix bugs in GCC 4.4's strict aliasing code by turning it off
+target_compile_options(core PUBLIC -fno-strict-aliasing)
+
+# Make core includes available without directories
+target_include_directories(core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/core)
+
+# Link against FLAC library
+find_package(FLAC)
+if(FLAC_FOUND)
+	target_compile_definitions(core PRIVATE -DG3_HAS_FLAC)
+	target_include_directories(core PRIVATE ${FLAC_INCLUDE_DIR})
+	target_link_libraries(core ${FLAC_LIBRARIES})
+endif()
+
+# Boost bits we need
+find_package(PythonInterp)
+find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+set(Boost_NO_BOOST_CMAKE ON)
+
+if(NOT DEFINED Boost_PYTHON_TYPE)
+	set(Boost_PYTHON_TYPE python)
+
+	# Detect attempts to be clever with the naming of the Boost Python library
+	string(REGEX REPLACE ".*libpython([0-9])\\.[0-9]+.*\\..*" "\\1" PYTHONMAJORVER ${PYTHON_LIBRARIES})
+	string(REGEX REPLACE ".*libpython[0-9]\\.([0-9]+).*\\..*" "\\1" PYTHONMINORVER ${PYTHON_LIBRARIES})
+
+	# Hack for some old Boost CMake modules
+	set(_Boost_PYTHON${PYTHONMAJORVER}_HEADERS "boost/python.hpp")
+	set(_Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_HEADERS "boost/python.hpp")
+
+	find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER}${PYTHONMINORVER})
+	if (${Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_FOUND})
+		set(Boost_PYTHON_TYPE python${PYTHONMAJORVER}${PYTHONMINORVER})
+	else()
+		find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER})
+		if (${Boost_PYTHON${PYTHONMAJORVER}_FOUND})
+			set(Boost_PYTHON_TYPE python${PYTHONMAJORVER})
+		endif()
+	endif()
+endif()
+
+find_package(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
+if(Boost_VERSION EQUAL 104700 OR Boost_VERSION GREATER 104700)
+	set(Boost_GEOMETRY_AVAIL ON)
+	message(STATUS "Boost Geometry Available")
+endif()
+
+target_include_directories(core PUBLIC ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_PATH})
+target_link_libraries(core pthread ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+
+# Work around yet more bugs in GCC 4.4, this time with C++ 11 support
+target_compile_definitions(core PUBLIC -DBOOST_NO_CXX11_SMART_PTR=1)
+
 link_python_dir()
+
 execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/bin/spt3g-dump ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/bin/spt3g-verify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 execute_process(COMMAND ln -fsn ${CMAKE_CURRENT_SOURCE_DIR}/bin/spt3g-inspect ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,11 +17,8 @@ add_spt3g_library(core SHARED
 	src/G3PipelineInfo.cxx src/G3Quat.cxx
 )
 
-# Ignore known warnings
-target_compile_options(core PUBLIC -Wno-unknown-warning-option -Wno-unused -Wno-unused-result -Wno-deprecated-register -Wno-sign-compare -Wno-constant-conversion -Wno-self-assign-overloaded -Wno-deprecated-declarations)
-
-# Fix bugs in GCC 4.4's strict aliasing code by turning it off
-target_compile_options(core PUBLIC -fno-strict-aliasing)
+# Link dependencies
+target_link_libraries(core spt3g)
 
 # Make core includes available without directories
 target_include_directories(core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/core)
@@ -33,49 +30,6 @@ if(FLAC_FOUND)
 	target_include_directories(core PRIVATE ${FLAC_INCLUDE_DIR})
 	target_link_libraries(core ${FLAC_LIBRARIES})
 endif()
-
-# Boost bits we need
-find_package(PythonInterp)
-find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-set(Boost_NO_BOOST_CMAKE ON)
-
-if(NOT DEFINED Boost_PYTHON_TYPE)
-	set(Boost_PYTHON_TYPE python)
-
-	# Detect attempts to be clever with the naming of the Boost Python library
-	string(REGEX REPLACE ".*libpython([0-9])\\.[0-9]+.*\\..*" "\\1" PYTHONMAJORVER ${PYTHON_LIBRARIES})
-	string(REGEX REPLACE ".*libpython[0-9]\\.([0-9]+).*\\..*" "\\1" PYTHONMINORVER ${PYTHON_LIBRARIES})
-
-	# Hack for some old Boost CMake modules
-	set(_Boost_PYTHON${PYTHONMAJORVER}_HEADERS "boost/python.hpp")
-	set(_Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_HEADERS "boost/python.hpp")
-
-	find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER}${PYTHONMINORVER})
-	if (${Boost_PYTHON${PYTHONMAJORVER}${PYTHONMINORVER}_FOUND})
-		set(Boost_PYTHON_TYPE python${PYTHONMAJORVER}${PYTHONMINORVER})
-	else()
-		find_package(Boost QUIET COMPONENTS python${PYTHONMAJORVER})
-		if (${Boost_PYTHON${PYTHONMAJORVER}_FOUND})
-			set(Boost_PYTHON_TYPE python${PYTHONMAJORVER})
-		endif()
-	endif()
-endif()
-
-find_package(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
-if(Boost_VERSION EQUAL 104700 OR Boost_VERSION GREATER 104700)
-	set(Boost_GEOMETRY_AVAIL ON)
-	message(STATUS "Boost Geometry Available")
-endif()
-
-target_include_directories(core PUBLIC ${Boost_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS} ${PYTHON_INCLUDE_PATH})
-target_link_libraries(core pthread ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
-
-# Work around yet more bugs in GCC 4.4, this time with C++ 11 support
-target_compile_definitions(core PUBLIC -DBOOST_NO_CXX11_SMART_PTR=1)
 
 link_python_dir()
 

--- a/dfmux/CMakeLists.txt
+++ b/dfmux/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 	set(DFMUX_LIB_EXTRA_LIB "")
 endif()
 
-add_library(dfmux SHARED
+add_spt3g_library(dfmux SHARED
 	src/DfMuxBuilder.cxx src/DfMuxCollector.cxx src/DfMuxSample.cxx
 	src/LegacyDfMuxCollector.cxx src/HardwareMap.cxx src/DfMuxCollator.cxx
 	src/Housekeeping.cxx src/python.cxx

--- a/gcp/CMakeLists.txt
+++ b/gcp/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(gcp SHARED
+add_spt3g_library(gcp SHARED
 	src/ARCFileReader.cxx src/python.cxx
 	src/ACUStatus.cxx src/TrackerStatus.cxx src/TrackerPointing.cxx
 	src/GCPMuxDataDecoder.cxx src/GCPLogger.cxx


### PR DESCRIPTION
 * Common set of convenience functions and variables output to `<build>/cmake/Spt3gIncludes.cmake`
 * Add `spt3g::spt3g` interface build target to easily build against all SPT3G required dependencies with correct compiler options
 * Add smart interface properties to all library build targets (`spt3g::core` etc) to allow building against them with all required dependencies compiler options
 * Automatically generated list of library targets stored in `<build>/cmake/Spt3gTargets.cmake`
 * Configuration file for inclusion into other projects output to `<build>/cmake/Spt3gConfig.cmake`
   * Define `SPT3G_SOURCE_DIR`, `SPT3G_BUILD_DIR`, `SPT3G_LIBRARY_DIR` and `SPT3G_RUNTIME_DIR` cmake variables
   * Define `SPT3G_LIBRARIES` variable with all built targets, and `SPT3G_INCLUDE_DIRS` variable with all library include directories

To build a library in a separate project against the spt3g core library, add the following to your `CMakeLists.txt` file:

    find_package(Spt3g)
    if (SPT3G_FOUND)
        target_link_libraries(mylib spt3g::core)
    endif()

To ensure that the Spt3g cmake directory is in the cmake search path, call cmake with:

    cmake -DCMAKE_PREFIX_PATH=/path/to/spt3g_software_build