### PR TITLE
Extract a minimal amount of data from a GCPSlow frame

### DIFF
--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -228,6 +228,9 @@ def UnpackTrackerData(f, rewrite_source_from_feature_bits=True):
     to that value.
     '''
 
+    if f.type != core.G3FrameType.GcpSlow:
+        return
+
     UnpackTrackerMinimal(f, rewrite_source_from_feature_bits)
 
     t = TrackerStatus()

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -184,8 +184,9 @@ def UnpackACUData(f):
 @core.indexmod
 def UnpackTrackerMinimal(f, rewrite_source_from_feature_bits=True):
     '''
-    Construct SourceName and ObservationId keys from frame. If
-    rewrite_source_from_feature_bits is True (the default), will try to
+    Construct SourceName and ObservationId keys from frame.
+
+    If rewrite_source_from_feature_bits is True (the default), will try to
     rewrite source names if DecryptFeatureBit() has been run and either
     "elnod", "calibrator", or "noise" is present in the feature bit list
     to that value.
@@ -218,8 +219,10 @@ def UnpackTrackerMinimal(f, rewrite_source_from_feature_bits=True):
 @core.indexmod
 def UnpackTrackerData(f, rewrite_source_from_feature_bits=True):
     '''
-    Extracts tracker status information to frame. If
-    rewrite_source_from_feature_bits is True (the default), will try to
+    Extracts tracker status information to frame into the TrackerStatus key,
+    along with the observation processing handled by UnpackTrackerMinimal.
+
+    If rewrite_source_from_feature_bits is True (the default), will try to
     rewrite source names if DecryptFeatureBit() has been run and either
     "elnod", "calibrator", or "noise" is present in the feature bit list
     to that value.

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -182,9 +182,9 @@ def UnpackACUData(f):
     f['ACUStatus'] = a
 
 @core.indexmod
-def UnpackTrackerData(f, rewrite_source_from_feature_bits=True):
+def UnpackTrackerMinimal(f, rewrite_source_from_feature_bits=True):
     '''
-    Extracts tracker status information to frame. If
+    Construct SourceName and ObservationId keys from frame. If
     rewrite_source_from_feature_bits is True (the default), will try to
     rewrite source names if DecryptFeatureBit() has been run and either
     "elnod", "calibrator", or "noise" is present in the feature bit list
@@ -213,6 +213,19 @@ def UnpackTrackerData(f, rewrite_source_from_feature_bits=True):
     # And observation ID, if present
     if 'obs_id' in f['antenna0']['tracker']:
         f['ObservationID'] = f['antenna0']['tracker']['obs_id']
+
+
+@core.indexmod
+def UnpackTrackerData(f, rewrite_source_from_feature_bits=True):
+    '''
+    Extracts tracker status information to frame. If
+    rewrite_source_from_feature_bits is True (the default), will try to
+    rewrite source names if DecryptFeatureBit() has been run and either
+    "elnod", "calibrator", or "noise" is present in the feature bit list
+    to that value.
+    '''
+
+    UnpackTrackerMinimal(f, rewrite_source_from_feature_bits)
 
     t = TrackerStatus()
     # List comprehensions are due to funny business with G3VectorFrameObject
@@ -363,5 +376,16 @@ def ARCExtract(pipe):
     pipe.Add(DecryptFeatureBit)
     pipe.Add(UnpackTrackerData)
     pipe.Add(AddBenchData)
+
+
+@core.pipesegment
+def ARCExtractMinimal(pipe):
+    '''Extract bare minimum GCP registers into native objects.
+
+    Includes only GCPFeatureBits, SourceName and ObservationID keys.
+    Use ARCExtract to calibrate and extract the complete frame.
+    '''
+    pipe.Add(DecryptFeatureBit)
+    pipe.Add(UnpackTrackerMinimal)
 
 # Need tool for tilt meter next

--- a/gcp/python/__init__.py
+++ b/gcp/python/__init__.py
@@ -1,7 +1,7 @@
 from spt3g.core.load_pybindings import load_pybindings
 load_pybindings(__name__, __path__)
 
-from .ARCExtractor import UnpackACUData, UnpackTrackerData, DecryptFeatureBit, ARCExtract
+from .ARCExtractor import UnpackACUData, UnpackTrackerData, DecryptFeatureBit, ARCExtract, ARCExtractMinimal
 from .ARCHKExtractor import UnpackSPTpolHKData
 from .GCPDataTee import GCPHousekeepingTee, GCPSignalledHousekeeping, GCPBoloDataTee, GCPWatchdog
 


### PR DESCRIPTION
This allows more efficient processing of arcfile data when no calibration or
re-packaging of data are necessary (e.g. searching for observation or schedule
start/stop times).