### PR TITLE
Allow streaming arcfile data from a network source (e.g. GCP)

### DIFF
--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -8,7 +8,7 @@
 // Knows how to decompress files if compressed (based on filename extension),
 // read files from disk, and from network sockets
 
-void g3_istream_from_path(boost::iostreams::filtering_istream &stream,
+int g3_istream_from_path(boost::iostreams::filtering_istream &stream,
     const std::string &path, float timeout=-1.0);
 
 #endif

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -41,7 +41,7 @@ void G3Reader::StartFile(std::string path)
 {
 	log_info("Starting file %s\n", path.c_str());
 	cur_file_ = path;
-	g3_istream_from_path(stream_, path, timeout_);
+	(void) g3_istream_from_path(stream_, path, timeout_);
 }
 
 void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -16,7 +16,7 @@
 #include <netdb.h>
 #include <stdlib.h>
 
-void
+int
 g3_istream_from_path(boost::iostreams::filtering_istream &stream,
     const std::string &path, float timeout)
 {
@@ -26,6 +26,8 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 	if (boost::algorithm::ends_with(path, ".bz2"))
 		stream.push(boost::iostreams::bzip2_decompressor());
 
+	int fd = -1;
+
 	// Figure out what kind of ultimate data source this is
 	if (path.find("tcp://") == 0) {
 		// TCP Socket. Two syntaxes:
@@ -34,7 +36,6 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 		// - tcp://*:port -> listen on "port" for the first connection
 		//   and read until EOF
 
-		int fd;
 		std::string host = path.substr(path.find("://") + 3);
 		if (host.find(":") == -1)
 			log_fatal("Could not open URL %s: unspecified port",
@@ -140,6 +141,7 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 		// Simple file case
 		stream.push(boost::iostreams::file_source(path,
 		    std::ios::binary));
-	}	
-}
+	}
 
+	return fd;
+}


### PR DESCRIPTION
This change allows the ARCFileReader to inject GcpSlow frames directly into a
G3Pipeline by connecting to a running GCP session.  Use "tcp://host:port" to
connect.  The port should be the CP_MONITOR_PORT as defined in
gcp/bin/control/ports.h (e.g. 5482 for SPT).

The network protocol differs slightly from the file protocol.  A handshake is
required over the TCP connection to initiate the register stream.  Further
improvements to the code could allow adjusting the contents of the received
frames, and the interval (in source frames) between them.  By default, all
available registers are sent at the source frame rate.  This includes unarchived
registers that appear in the live stream but are never written to arcfiles.