### PR TITLE
quaternions: ~ operator does conj(), __abs__, and new "/" overloads

### DIFF
--- a/core/include/core/G3Quat.h
+++ b/core/include/core/G3Quat.h
@@ -33,11 +33,17 @@ double dot3(quat a, quat b);
 
 G3VECTOR_OF(quat, G3VectorQuat);
 
+quat operator ~(quat);
+G3VectorQuat operator ~ (const G3VectorQuat &);
 G3VectorQuat operator * (const G3VectorQuat &, double);
 G3VectorQuat &operator *= (G3VectorQuat &, double);
 G3VectorQuat operator / (const G3VectorQuat &, double);
+G3VectorQuat operator / (double , const G3VectorQuat &);
+G3VectorQuat operator / (const G3VectorQuat &, const quat &);
+G3VectorQuat operator / (const quat &, const G3VectorQuat &);
 G3VectorQuat operator / (const G3VectorQuat &, const G3VectorQuat &);
 G3VectorQuat &operator /= (G3VectorQuat &, double);
+G3VectorQuat &operator /= (G3VectorQuat &, const quat &);
 G3VectorQuat &operator /= (G3VectorQuat &, const G3VectorQuat &);
 G3VectorQuat operator * (const G3VectorQuat &, const G3VectorQuat &);
 G3VectorQuat &operator *= (G3VectorQuat &, const G3VectorQuat &);

--- a/core/src/G3Quat.cxx
+++ b/core/src/G3Quat.cxx
@@ -27,6 +27,36 @@ dot3(quat a, quat b)
 		a.R_component_4()*b.R_component_4());
 }
 
+static double
+_abs(const quat &a)
+{
+	return sqrt(norm(a));
+}
+
+static G3VectorDouble
+_vabs(const G3VectorQuat &a)
+{
+	G3VectorDouble out(a.size());
+	for (unsigned i = 0; i < a.size(); i++)
+                out[i] = _abs(a[i]);
+	return out;
+}
+
+quat
+operator ~(quat a)
+{
+	return conj(a);
+}
+
+G3VectorQuat
+operator ~(const G3VectorQuat &a)
+{
+	G3VectorQuat out(a.size());
+        for (unsigned i = 0; i < a.size(); i++)
+		out[i] = conj(a[i]);
+	return out;
+}
+
 G3VectorQuat
 operator *(const G3VectorQuat &a, double b)
 {
@@ -60,6 +90,33 @@ operator /(const G3VectorQuat &a, double b)
 }
 
 G3VectorQuat
+operator /(double a, const G3VectorQuat &b)
+{
+	G3VectorQuat out(b.size());
+	for (unsigned i = 0; i < b.size(); i++)
+		out[i] = a/b[i];
+	return out;
+}
+
+G3VectorQuat
+operator /(const G3VectorQuat &a, const quat &b)
+{
+	G3VectorQuat out(a.size());
+	for (unsigned i = 0; i < a.size(); i++)
+		out[i] = a[i]/b;
+	return out;
+}
+
+G3VectorQuat
+operator /(const quat &a, const G3VectorQuat &b)
+{
+	G3VectorQuat out(b.size());
+	for (unsigned i = 0; i < b.size(); i++)
+		out[i] = a/b[i];
+	return out;
+}
+
+G3VectorQuat
 operator /(const G3VectorQuat &a, const G3VectorQuat &b)
 {
 	g3_assert(a.size() == b.size());
@@ -74,6 +131,14 @@ operator /=(G3VectorQuat &a, double b)
 {
 	for (quat &i: a)
 		i /= b;
+	return a;
+}
+
+G3VectorQuat &
+operator /=(G3VectorQuat &a, const quat &b)
+{
+	for (unsigned i = 0; i < a.size(); i++)
+		a[i] /= b;
 	return a;
 }
 
@@ -268,6 +333,7 @@ PYBINDINGS("core")
 	     .add_property("b", &quat::R_component_2)
 	     .add_property("c", &quat::R_component_3)
 	     .add_property("d", &quat::R_component_4)
+	     .def(~self)
 	     .def(self == self)
 	     .def(self != self)
 	     .def(self + self)
@@ -283,8 +349,10 @@ PYBINDINGS("core")
 	     .def(pow(self, long()))
 	     .def(self / self)
 	     .def(self / double())
+	     .def(double() / self)
 	     .def(self /= self)
 	     .def(self /= double())
+	     .def("__abs__", _abs)
 	     .def("__str__", quat_str)
 	     .def("__repr__", quat_repr)
 	     .def("dot3", dot3, "Dot product of last three entries")
@@ -293,6 +361,7 @@ PYBINDINGS("core")
 	register_vector_of<quat>("QuatVector");
 	object vq =
 	    register_g3vector<quat>("G3VectorQuat", "List of quaternions")
+	     .def(~self)
 	     .def(self * double())
 	     .def(double() * self)
 	     .def(self * self)
@@ -302,11 +371,16 @@ PYBINDINGS("core")
 	     .def(self *= quat())
 	     .def(self *= self)
 	     .def(self / double())
+	     .def(double() / self)
 	     .def(self /= double())
 	     .def(self / self)
 	     .def(self /= self)
+	     .def(self / quat())
+	     .def(self /= quat())
+	     .def(quat() / self)
 	     .def(pow(self, double()))
-	     .def(pow(self, int()));
+	     .def(pow(self, int()))
+	     .def("__abs__", _vabs);
 	PyTypeObject *vqclass = (PyTypeObject *)vq.ptr();
 	vectorquat_bufferprocs.bf_getbuffer = G3VectorQuat_getbuffer;
 	vqclass->tp_as_buffer = &vectorquat_bufferprocs;

--- a/core/tests/quaternions.py
+++ b/core/tests/quaternions.py
@@ -48,3 +48,8 @@ assert((np.asarray(b)/2 == np.asarray(e)).all())
 
 assert((np.asarray(b*b) == np.asarray(core.G3VectorQuat([x**2 for x in b]))).all())
 
+assert(1./a == core.quat(1.,0,0,0)/a)
+assert(1./a == (~a) / abs(a)**2)
+assert((np.asarray(abs(b) - abs(~b)) == 0).all())
+assert(a/b[0] == (a/b)[0])
+assert(b[1]/a == (b/a)[1])


### PR DESCRIPTION
For quaternions that express rotations in 3d, the inverse of q =
(a,b,c,d) is q^-1 = (a,-b,-c,-d) and has the effect of "undoing" the
rotation q.  Here we improve access to q^-1 by:

* Defining the ~ operator on quat and G3VectorQuat, as a quick way to
  get conjugates.
* Defining ``__abs__``, so (in Python) ``abs(q)`` returns the Euclidean norm
  sqrt(a^2+b^2+c^2+d^2)
* Overloading the / operator further, to support all combinations of
  double, quat, and G3VectorQuat.