### PR TITLE
In-place Sort() method for G3TimesampleMap objects

### DIFF
--- a/core/include/core/G3Timesample.h
+++ b/core/include/core/G3Timesample.h
@@ -18,6 +18,7 @@ public:
 	G3VectorTime times;
 	G3TimesampleMap Concatenate(const G3TimesampleMap &other) const;
 	bool Check() const;
+	void Sort();
 
 	string Description() const;
 	string Summary() const;

--- a/core/include/core/G3Timesample.h
+++ b/core/include/core/G3Timesample.h
@@ -33,6 +33,7 @@ namespace cereal {
 	    A, G3TimesampleMap, cereal::specialization::member_serialize> {};
 }
 
+G3_POINTERS(G3TimesampleMap);
 G3_SERIALIZABLE(G3TimesampleMap, 0);
 
 class g3timesample_exception : std::exception

--- a/core/src/G3Timesample.cxx
+++ b/core/src/G3Timesample.cxx
@@ -74,17 +74,17 @@ void vect_reorder(vectype &dest, vectype &src, const std::vector<size_t> &idx)
 }
 
 // Reorders elements of a vector, in place.
-// Returns -1 on any incompatibility.
+// Returns false on any incompatibility.
 template <typename g3vectype>
 inline
-int test_and_reorder(G3FrameObjectPtr &src, const std::vector<size_t> &idx)
+bool test_and_reorder(G3FrameObjectPtr &src, const std::vector<size_t> &idx)
 {
 	auto v = boost::dynamic_pointer_cast<g3vectype>(src);
 	if (v == nullptr)
-		return -1;
+		return false;
 	g3vectype v2 = *v; // copy
 	vect_reorder(*v, v2, idx);
-	return 0;
+	return true;
 }
 
 
@@ -202,9 +202,9 @@ void G3TimesampleMap::Sort()
 
 	for (auto item = begin(); item != end(); item++) {
 		if (
-			test_and_reorder<G3VectorDouble>(item->second, idx) &&
-			test_and_reorder<G3VectorInt>(item->second, idx) &&
-			test_and_reorder<G3VectorString>(item->second, idx)
+			!test_and_reorder<G3VectorDouble>(item->second, idx) &&
+			!test_and_reorder<G3VectorInt>(item->second, idx) &&
+			!test_and_reorder<G3VectorString>(item->second, idx)
 			) {
 			std::ostringstream s;
 			s << "Vector type not supported for key: " << item->first << "\n";

--- a/core/src/G3Timesample.cxx
+++ b/core/src/G3Timesample.cxx
@@ -277,11 +277,11 @@ PYBINDINGS("core")
 	// Extensions for G3TimesampleMap are here:
 	.add_property("times", &G3TimesampleMap::times, &safe_set_times,
 	  "Times vector.  Setting this stores a copy, but getting returns a reference.")
-	.def("Check", &G3TimesampleMap::Check, "Check for internal "
+	.def("check", &G3TimesampleMap::Check, "Check for internal "
           "consistency.  Raises ValueError if there are problems.")
-	.def("Concatenate", &G3TimesampleMap::Concatenate,
+	.def("concatenate", &G3TimesampleMap::Concatenate,
           "Concatenate two compatible G3TimesampleMap.")
-	.def("Sort", &G3TimesampleMap::Sort,
+	.def("sort", &G3TimesampleMap::Sort,
           "Sort all element vectors by time, in-place.")
 	;
 	register_pointer_conversions<G3TimesampleMap>();

--- a/core/tests/timesample.py
+++ b/core/tests/timesample.py
@@ -31,7 +31,7 @@ class TestTimesampleMap(unittest.TestCase):
     def test_00_internal_checks(self):
         # Valid block.
         m = get_test_block(100, ['x', 'y', 'z'])
-        m.Check()
+        m.check()
 
     def test_10_safety(self):
         m0 = get_test_block(100, ['x', 'y', 'z'])
@@ -52,7 +52,7 @@ class TestTimesampleMap(unittest.TestCase):
         key_list = ['x', 'y', 'z']
         m0 = get_test_block(100, key_list)
         m1 = get_test_block(200, key_list, offset=100)
-        m01 = m0.Concatenate(m1)
+        m01 = m0.concatenate(m1)
         self.assertTrue(np.all(
             np.hstack([np.array(m0.times), np.array(m1.times)]) == np.array(m01.times)))
         for k in key_list:
@@ -63,28 +63,28 @@ class TestTimesampleMap(unittest.TestCase):
                 get_test_block(200, key_list[:-1], 100),
                 ]:
             with self.assertRaises(ValueError):
-                m0.Concatenate(fail_vec)
+                m0.concatenate(fail_vec)
 
     def test_30_serialization(self):
         m0 = get_test_block(100, ['x', 'y', 'z', 'A'])
         m1 = get_test_block(200, ['x', 'y', 'z', 'A'], 100)
-        m2 = m0.Concatenate(m1)
-        m0.Check()
-        m1.Check()
-        m2.Check()
+        m2 = m0.concatenate(m1)
+        m0.check()
+        m1.check()
+        m2.check()
         f = core.G3Frame()
         f['irreg0'] = m0
         f['irreg1'] = m1
         core.G3Writer('test.g3').Process(f)
         f = core.G3Reader('test.g3').Process(None)[0]
-        f['irreg0'].Check()
-        f['irreg1'].Check()
-        f['irreg0'].Concatenate(f['irreg1'])['x']
+        f['irreg0'].check()
+        f['irreg1'].check()
+        f['irreg0'].concatenate(f['irreg1'])['x']
 
     def test_40_sort(self):
         m0 = get_test_block(100, ['x', 'y', 'z'], ordered=False)
         m1 = copy.deepcopy(m0)
-        m0.Sort()
+        m0.sort()
         idx = np.argsort(m1.times)
         self.assertTrue((np.asarray(m1.times)[idx] == np.asarray(m0.times)).all())
         for k in ['x', 'y', 'z']:


### PR DESCRIPTION
This method is useful when the contents of a G3TimestreamMap object are
unordered in time, e.g. when constructed from out-of-order packets.

All sorting operations are done on one vector at a time with replacement, to
minimize the required memory footprint.