### PR TITLE
Check units in map arithmetic

### DIFF
--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -397,14 +397,12 @@ G3SkyMap &FlatSkyMap::operator op(const G3SkyMap &rhs) {\
 flatskymap_arithmetic(+=, {}, {g3_assert(units == rhs.units);})
 flatskymap_arithmetic(-=, {}, {g3_assert(units == rhs.units);})
 flatskymap_arithmetic(/=, {ConvertToDense(); (*this->dense_) /= 0.0;},
-    {if (units == G3Timestream::None) units = rhs.units; else if (rhs.units != G3Timestream::None) g3_assert(units == rhs.units);})
+    {if (units == G3Timestream::None) units = rhs.units;})
 
 G3SkyMap &FlatSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
-	else if (rhs.units != G3Timestream::None)
-		g3_assert(units == rhs.units);
 	try {
 		const FlatSkyMap& b = dynamic_cast<const FlatSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -357,9 +357,10 @@ FlatSkyMap::operator [] (size_t i)
 	return (*this)(i % xpix_, i / xpix_);
 }
 
-#define flatskymap_arithmetic(op, sparsenull) \
+#define flatskymap_arithmetic(op, sparsenull, unitscheck) \
 G3SkyMap &FlatSkyMap::operator op(const G3SkyMap &rhs) {\
 	g3_assert(IsCompatible(rhs)); \
+	unitscheck \
 	try { \
 		const FlatSkyMap& b = dynamic_cast<const FlatSkyMap &>(rhs); \
 		if (dense_) { \
@@ -393,12 +394,15 @@ G3SkyMap &FlatSkyMap::operator op(const G3SkyMap &rhs) {\
 	} \
 }
 
-flatskymap_arithmetic(+=, {})
-flatskymap_arithmetic(-=, {})
-flatskymap_arithmetic(/=, {ConvertToDense(); (*this->dense_) /= 0.0;})
+flatskymap_arithmetic(+=, {}, {g3_assert(units == rhs.units);})
+flatskymap_arithmetic(-=, {}, {g3_assert(units == rhs.units);})
+flatskymap_arithmetic(/=, {ConvertToDense(); (*this->dense_) /= 0.0;},
+    {if (units == G3Timestream::None) units = rhs.units;})
 
 G3SkyMap &FlatSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
+	if (units == G3Timestream::None)
+		units = rhs.units;
 	try {
 		const FlatSkyMap& b = dynamic_cast<const FlatSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -397,12 +397,14 @@ G3SkyMap &FlatSkyMap::operator op(const G3SkyMap &rhs) {\
 flatskymap_arithmetic(+=, {}, {g3_assert(units == rhs.units);})
 flatskymap_arithmetic(-=, {}, {g3_assert(units == rhs.units);})
 flatskymap_arithmetic(/=, {ConvertToDense(); (*this->dense_) /= 0.0;},
-    {if (units == G3Timestream::None) units = rhs.units;})
+    {if (units == G3Timestream::None) units = rhs.units; else if (rhs.units != G3Timestream::None) g3_assert(units == rhs.units);})
 
 G3SkyMap &FlatSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	else if (rhs.units != G3Timestream::None)
+		g3_assert(units == rhs.units);
 	try {
 		const FlatSkyMap& b = dynamic_cast<const FlatSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -200,8 +200,6 @@ G3SkyMap &G3SkyMap::operator*=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
-	else if (rhs.units != G3Timestream::None)
-		g3_assert(units == rhs.units);
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] *= rhs[i];
@@ -220,8 +218,6 @@ G3SkyMap &G3SkyMap::operator/=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
-	else if (rhs.units != G3Timestream::None)
-		g3_assert(units == rhs.units);
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] /= rhs[i];

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -166,6 +166,7 @@ size_t G3SkyMap::size() const
 G3SkyMap &G3SkyMap::operator+=(const G3SkyMap & rhs)
 {
 	g3_assert(IsCompatible(rhs));
+	g3_assert(units == rhs.units);
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] += rhs[i];
 	return *this;
@@ -181,6 +182,7 @@ G3SkyMap &G3SkyMap::operator+=(double rhs)
 G3SkyMap &G3SkyMap::operator-=(const G3SkyMap &rhs)
 {
 	g3_assert(IsCompatible(rhs));
+	g3_assert(units == rhs.units);
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] -= rhs[i];
 	return *this;
@@ -196,6 +198,9 @@ G3SkyMap &G3SkyMap::operator-=(double rhs)
 G3SkyMap &G3SkyMap::operator*=(const G3SkyMap &rhs)
 {
 	g3_assert(IsCompatible(rhs));
+	if (units == G3Timestream::None)
+		units = rhs.units;
+
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] *= rhs[i];
 	return *this;
@@ -211,6 +216,9 @@ G3SkyMap &G3SkyMap::operator*=(double rhs)
 G3SkyMap &G3SkyMap::operator/=(const G3SkyMap &rhs)
 {
 	g3_assert(IsCompatible(rhs));
+	if (units == G3Timestream::None)
+		units = rhs.units;
+
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] /= rhs[i];
 	return *this;
@@ -412,6 +420,7 @@ static void
 pyskymap_ipow(G3SkyMap &a, const G3SkyMap &b)
 {
 	g3_assert(a.IsCompatible(b));
+	g3_assert(b.units == G3Timestream::None);
 	for (size_t i = 0; i < a.size(); i++) {
 		double va = a.at(i);
 		double vb = b.at(i);
@@ -434,6 +443,7 @@ static G3SkyMapPtr \
 pyskymap_##name(const G3SkyMap &a, const G3SkyMap &b) \
 { \
 	g3_assert(a.IsCompatible(b)); \
+	g3_assert(a.units == b.units); \
 	G3SkyMapPtr rv = a.Clone(false); \
 	for (size_t i = 0; i < a.size(); i++) { \
 		if (a.at(i) oper b.at(i)) \

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -200,6 +200,8 @@ G3SkyMap &G3SkyMap::operator*=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	else if (rhs.units != G3Timestream::None)
+		g3_assert(units == rhs.units);
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] *= rhs[i];
@@ -218,6 +220,8 @@ G3SkyMap &G3SkyMap::operator/=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	else if (rhs.units != G3Timestream::None)
+		g3_assert(units == rhs.units);
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] /= rhs[i];

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -556,8 +556,6 @@ G3SkyMap &HealpixSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
-	else if (rhs.units != G3Timestream::None)
-		g3_assert(units == rhs.units);
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;
@@ -594,8 +592,6 @@ G3SkyMap &HealpixSkyMap::operator /=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
-	else if (rhs.units != G3Timestream::None)
-		g3_assert(units == rhs.units);
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -556,6 +556,8 @@ G3SkyMap &HealpixSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	else if (rhs.units != G3Timestream::None)
+		g3_assert(units == rhs.units);
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;
@@ -592,6 +594,8 @@ G3SkyMap &HealpixSkyMap::operator /=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	else if (rhs.units != G3Timestream::None)
+		g3_assert(units == rhs.units);
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -517,6 +517,7 @@ HealpixSkyMap::operator [] (size_t i)
 #define healpixskymap_arithmetic(op) \
 G3SkyMap &HealpixSkyMap::operator op(const G3SkyMap &rhs) { \
 	g3_assert(IsCompatible(rhs)); \
+	g3_assert(units == rhs.units); \
 	try { \
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs); \
 		if (dense_ || ring_sparse_ || indexed_sparse_) { \
@@ -553,6 +554,8 @@ healpixskymap_arithmetic(-=)
 
 G3SkyMap &HealpixSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
+	if (units == G3Timestream::None)
+		units = rhs.units;
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;
@@ -587,6 +590,8 @@ G3SkyMap &HealpixSkyMap::operator *=(const G3SkyMap &rhs) {
 
 G3SkyMap &HealpixSkyMap::operator /=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
+	if (units == G3Timestream::None)
+		units = rhs.units;
 	try {
 		const HealpixSkyMap& b = dynamic_cast<const HealpixSkyMap &>(rhs);
 		bool zero = false;


### PR DESCRIPTION
Ensure that units match when adding, subtracting or comparing two maps together.
When multiplying or dividing maps, ensure that the unitful map's units get
propagated to the output map.