### PR TITLE
OSX Testing Workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04] #, macOS-latest] # macOS disabled because of lameness with Homebrew Boost
+        os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
     runs-on: ${{ matrix.os}}
 
     steps:
@@ -22,7 +22,7 @@ jobs:
         if [ `echo ${{matrix.os}} | cut -d - -f 1` = "ubuntu" ]; then
           sudo apt-get install libboost-all-dev libflac-dev libnetcdf-dev libfftw3-dev libgsl0-dev python python3 python3-pip
         elif [ `echo ${{matrix.os}} | cut -d - -f 1` = "macOS" ]; then
-          brew install boost boost-python3 flac netcdf fftw gsl python
+          brew install python@3.9 boost boost-python3 flac netcdf fftw gsl
         else
           echo 'No installed package manager!'
           exit 1
@@ -45,7 +45,11 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: |
+        if [ `echo ${{matrix.os}} | cut -d - -f 1` = "macOS" ]; then
+          export PATH=/usr/local/opt/python@3.9/bin:$PATH
+        fi
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,9 @@ jobs:
         if [ `echo ${{matrix.os}} | cut -d - -f 1` = "ubuntu" ]; then
           sudo apt-get install libboost-all-dev libflac-dev libnetcdf-dev libfftw3-dev libgsl0-dev python python3 python3-pip
         elif [ `echo ${{matrix.os}} | cut -d - -f 1` = "macOS" ]; then
-          brew install python@3.9 boost boost-python3 flac netcdf fftw gsl
+          brew install python@3.9
+          brew link python@3.9
+          brew install boost boost-python3 flac netcdf fftw gsl
         else
           echo 'No installed package manager!'
           exit 1
@@ -45,11 +47,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: |
-        if [ `echo ${{matrix.os}} | cut -d - -f 1` = "macOS" ]; then
-          export PATH=/usr/local/opt/python@3.9/bin:$PATH
-        fi
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install libboost-all-dev libflac-dev libnetcdf-dev libfftw3-dev libgsl0-dev python python3 python3-pip
         elif [ `echo ${{matrix.os}} | cut -d - -f 1` = "macOS" ]; then
           brew install python@3.9
-          brew link python@3.9
+          brew link --overwrite python@3.9
           brew install boost boost-python3 flac netcdf fftw gsl
         else
           echo 'No installed package manager!'

--- a/core/python/modconstruct.py
+++ b/core/python/modconstruct.py
@@ -1,4 +1,4 @@
-from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal, log_warn
+from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal, log_error
 try:
     from spt3g.core import multiprocess
     multiproc_avail = True
@@ -193,7 +193,7 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, **kwargs):
     if subprocess:
         import sys
         if sys.version_info[:2] > (3, 7):
-            log_warn("Subprocess option is disabled for python versions > 3.7")
+            log_error("Subprocess option is disabled for python versions > 3.7")
             subprocess = False
 
     addpipelineinfo = False

--- a/core/python/modconstruct.py
+++ b/core/python/modconstruct.py
@@ -1,4 +1,4 @@
-from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal, log_error
+from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal
 try:
     from spt3g.core import multiprocess
     multiproc_avail = True
@@ -189,12 +189,6 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, **kwargs):
     function. If subprocess is set to True, this module will be
     run in a separate process.
     '''
-
-    if subprocess:
-        import sys
-        if sys.version_info[:2] > (3, 7):
-            log_error("Subprocess option is disabled for python versions > 3.7")
-            subprocess = False
 
     addpipelineinfo = False
     if not hasattr(self, '_pipelineinfo'):

--- a/core/python/modconstruct.py
+++ b/core/python/modconstruct.py
@@ -1,4 +1,4 @@
-from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal
+from spt3g.core import G3Module, G3Pipeline, G3PipelineInfo, G3Frame, G3FrameType, G3Time, G3ModuleConfig, log_fatal, log_warn
 try:
     from spt3g.core import multiprocess
     multiproc_avail = True
@@ -189,6 +189,12 @@ def PipelineAddCallable(self, callable, name=None, subprocess=False, **kwargs):
     function. If subprocess is set to True, this module will be
     run in a separate process.
     '''
+
+    if subprocess:
+        import sys
+        if sys.version_info[:2] > (3, 7):
+            log_warn("Subprocess option is disabled for python versions > 3.7")
+            subprocess = False
 
     addpipelineinfo = False
     if not hasattr(self, '_pipelineinfo'):

--- a/core/python/multiprocess.py
+++ b/core/python/multiprocess.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info[:2] > (3, 7):
+    raise ImportError("Multiprocessing is disabled for python versions > 3.7")
+
 from multiprocessing import Process
 import socket, pickle, errno, struct, time
 

--- a/core/tests/multiproc.py
+++ b/core/tests/multiproc.py
@@ -6,38 +6,37 @@ import time, sys
 # File to disk
 n = 0
 def addinfo(fr):
-    global n
-    if fr.type != core.G3FrameType.Timepoint:
-        return
-    fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
-    fr['count'] = n
-    n += 1
+	global n
+	if fr.type != core.G3FrameType.Timepoint:
+		return
+	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
+	fr['count'] = n
+	n += 1
 m = 0
 def checkinfo(fr):
-    global m
-    if fr.type != core.G3FrameType.Timepoint:
-        return
-    if 'time' not in fr:
-        raise RuntimeError('No time key in frame')
-    if fr['count'] != m:
-        raise RuntimeError('Out of order frame')
-    m += 1
+	global m
+	if fr.type != core.G3FrameType.Timepoint:
+		return
+	if 'time' not in fr:
+		raise RuntimeError('No time key in frame')
+	if fr['count'] != m:
+		raise RuntimeError('Out of order frame')
+	m += 1
 
 if __name__ == '__main__':
+	if sys.version_info[:2] > (3, 7):
+		print('Subprocess option is disabled for python versions > 3.7')
+		raise SystemExit
 
-    if sys.version_info[:2] > (3, 7):
-        print('Subprocess option is disabled for python versions > 3.7')
-        raise SystemExit
+	pipe = core.G3Pipeline()
+	pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
+	pipe.Add(addinfo, subprocess=True)
+	pipe.Add(core.Dump)
+	pipe.Add(checkinfo)
+	pipe.Run()
 
-    pipe = core.G3Pipeline()
-    pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
-    pipe.Add(addinfo, subprocess=True)
-    pipe.Add(core.Dump)
-    pipe.Add(checkinfo)
-    pipe.Run()
-
-    if n != 0:
-        raise RuntimeError('Ran in same process!')
-    n = 10 # Different process, so don't get this back
-    if m != n:
-        raise RuntimeError('Wrong number of frames (%d should be %d)' % (m, n))
+	if n != 0:
+		raise RuntimeError('Ran in same process!')
+	n = 10 # Different process, so don't get this back
+	if m != n:
+		raise RuntimeError('Wrong number of frames (%d should be %d)' % (m, n))

--- a/core/tests/multiproc.py
+++ b/core/tests/multiproc.py
@@ -6,40 +6,38 @@ import time, sys
 # File to disk
 n = 0
 def addinfo(fr):
-	global n
-	if fr.type != core.G3FrameType.Timepoint:
-		return
-	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
-	fr['count'] = n
-	n += 1
+    global n
+    if fr.type != core.G3FrameType.Timepoint:
+        return
+    fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
+    fr['count'] = n
+    n += 1
 m = 0
 def checkinfo(fr):
-	global m
-	if fr.type != core.G3FrameType.Timepoint:
-		return
-	if 'time' not in fr:
-		print('No time key in frame')
-		sys.exit(1)
-	if fr['count'] != m:
-		print('Out of order frame')
-		sys.exit(1)
-	m += 1
+    global m
+    if fr.type != core.G3FrameType.Timepoint:
+        return
+    if 'time' not in fr:
+        raise RuntimeError('No time key in frame')
+    if fr['count'] != m:
+        raise RuntimeError('Out of order frame')
+    m += 1
 
 if __name__ == '__main__':
-	pipe = core.G3Pipeline()
-	pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
-	pipe.Add(addinfo, subprocess=True)
-	pipe.Add(core.Dump)
-	pipe.Add(checkinfo)
-	pipe.Run()
 
-	if n is not 0:
-		print('Ran in same process!')
-		sys.exit(1)
-	n = 10 # Different process, so don't get this back
-	if m != n:
-		print('Wrong number of frames (%d should be %d)' % (m, n))
-		sys.exit(1)
+    if sys.version_info[:2] > (3, 7):
+        print('Subprocess option is disabled for python versions > 3.7')
+        raise SystemExit
 
-	sys.exit(0)
+    pipe = core.G3Pipeline()
+    pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
+    pipe.Add(addinfo, subprocess=True)
+    pipe.Add(core.Dump)
+    pipe.Add(checkinfo)
+    pipe.Run()
 
+    if n != 0:
+        raise RuntimeError('Ran in same process!')
+    n = 10 # Different process, so don't get this back
+    if m != n:
+        raise RuntimeError('Wrong number of frames (%d should be %d)' % (m, n))


### PR DESCRIPTION
Fixes for the testing github action with OSX.

Also disable running pipeline modules in a subprocess in python version > 3.7 due to limitations with pickling the module objects, so that tests with the latest python version pass.  Save the correct fix for this for a future PR.
