### PR TITLE
Better handling of weights when performing arithmetic between FlatSkyMap objects

### DIFF
--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -422,15 +422,18 @@ G3SkyMap &FlatSkyMap::operator op(const G3SkyMap &rhs) {\
 	} \
 }
 
-flatskymap_arithmetic(+=, {}, {g3_assert(units == rhs.units);})
-flatskymap_arithmetic(-=, {}, {g3_assert(units == rhs.units);})
+flatskymap_arithmetic(+=, {}, {g3_assert(units == rhs.units); g3_assert(weighted == rhs.weighted);})
+flatskymap_arithmetic(-=, {}, {g3_assert(units == rhs.units); g3_assert(weighted == rhs.weighted);})
 flatskymap_arithmetic(/=, {ConvertToDense(); (*this->dense_) /= 0.0;},
-    {if (units == G3Timestream::None) units = rhs.units;})
+    {if (units == G3Timestream::None) units = rhs.units;
+     if (rhs.weighted and !(weighted)) weighted = true;})
 
 G3SkyMap &FlatSkyMap::operator *=(const G3SkyMap &rhs) {
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	if (rhs.weighted and !(weighted))
+		weighted = true;
 	try {
 		const FlatSkyMap& b = dynamic_cast<const FlatSkyMap &>(rhs);
 		bool zero = false;

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -222,6 +222,8 @@ G3SkyMap &G3SkyMap::operator+=(const G3SkyMap & rhs)
 {
 	g3_assert(IsCompatible(rhs));
 	g3_assert(units == rhs.units);
+	g3_assert(weighted == rhs.weighted);
+
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] += rhs[i];
 	return *this;
@@ -238,6 +240,8 @@ G3SkyMap &G3SkyMap::operator-=(const G3SkyMap &rhs)
 {
 	g3_assert(IsCompatible(rhs));
 	g3_assert(units == rhs.units);
+	g3_assert(weighted == rhs.weighted);
+
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] -= rhs[i];
 	return *this;
@@ -255,6 +259,8 @@ G3SkyMap &G3SkyMap::operator*=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	if (rhs.weighted and !(weighted))
+		weighted = true;
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] *= rhs[i];
@@ -273,6 +279,8 @@ G3SkyMap &G3SkyMap::operator/=(const G3SkyMap &rhs)
 	g3_assert(IsCompatible(rhs));
 	if (units == G3Timestream::None)
 		units = rhs.units;
+	if (rhs.weighted and !(weighted))
+		weighted = true;
 
 	for (size_t i = 0; i < rhs.size(); i++)
 		(*this)[i] /= rhs[i];


### PR DESCRIPTION
Previously, when multiplying or dividing a weighted map and an unweighted map, the weighted-ness of the result would depend on the order of the two input maps.  This PR makes the result always weighted (the logic being that generally, you are multiplying a weighted map by an unweighted apodization mask and still want the output map to be weighted).  It also raises an error when you try to add/subtract a weighted map and an unweighted map, since there is no reasonable case in which you should be doing this.