### PR TITLE
Consistent handling of `shift_ra` attribute for `HealpixSkyMap` objects

### DIFF
--- a/maps/include/maps/HealpixSkyMap.h
+++ b/maps/include/maps/HealpixSkyMap.h
@@ -32,6 +32,7 @@ public:
 	    MapCoordReference coord_ref = MapCoordReference::Equatorial,
 	    G3Timestream::TimestreamUnits u = G3Timestream::Tcmb,
 	    G3SkyMap::MapPolType pol_type = G3SkyMap::None,
+	    bool shift_ra = false,
 	    G3SkyMap::MapPolConv pol_conv = G3SkyMap::ConvNone);
 
 	HealpixSkyMap();

--- a/maps/python/azel.py
+++ b/maps/python/azel.py
@@ -123,7 +123,7 @@ def convert_azel_to_radec(az, el, location=spt, mjd=None):
         location=location,
         pressure=0,
     )
-    kt = k.transform_to(astropy.coordinates.FK5)
+    kt = k.transform_to(astropy.coordinates.FK5())
 
     ra = np.asarray(kt.ra / astropy.units.deg) * core.G3Units.deg
     dec = np.asarray(kt.dec / astropy.units.deg) * core.G3Units.deg
@@ -242,7 +242,7 @@ def convert_radec_to_gal(ra, dec):
         ra=np.asarray(ra) / core.G3Units.deg * astropy.units.deg,
         dec=np.asarray(dec) / core.G3Units.deg * astropy.units.deg,
     )
-    kt = k.transform_to(astropy.coordinates.Galactic)
+    kt = k.transform_to(astropy.coordinates.Galactic())
 
     glon = np.asarray(kt.l / astropy.units.deg) * core.G3Units.deg
     glat = np.asarray(kt.b / astropy.units.deg) * core.G3Units.deg
@@ -295,7 +295,7 @@ def convert_gal_to_radec(glon, glat):
         l=np.asarray(glon) / core.G3Units.deg * astropy.units.deg,
         b=np.asarray(glat) / core.G3Units.deg * astropy.units.deg,
     )
-    kt = k.transform_to(astropy.coordinates.FK5)
+    kt = k.transform_to(astropy.coordinates.FK5())
 
     ra = np.asarray(kt.ra / astropy.units.deg) * core.G3Units.deg
     dec = np.asarray(kt.dec / astropy.units.deg) * core.G3Units.deg

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -25,9 +25,9 @@ HealpixSkyMap::HealpixSkyMap(size_t nside, bool weighted, bool nested,
 HealpixSkyMap::HealpixSkyMap(boost::python::object v, bool weighted,
     bool nested, MapCoordReference coord_ref,
     G3Timestream::TimestreamUnits u, G3SkyMap::MapPolType pol_type,
-    G3SkyMap::MapPolConv pol_conv) :
+    bool shift_ra, G3SkyMap::MapPolConv pol_conv) :
       G3SkyMap(coord_ref, weighted, u, pol_type, pol_conv), nested_(nested),
-      dense_(NULL), ring_sparse_(NULL), indexed_sparse_(NULL), shift_ra_(false)
+      dense_(NULL), ring_sparse_(NULL), indexed_sparse_(NULL), shift_ra_(shift_ra)
 {
 	Py_buffer view;
 
@@ -1179,13 +1179,14 @@ PYBINDINGS("maps")
 	       "Instantiate a HealpixSkyMap with given nside"))
 	    .def(bp::init<boost::python::object, bool, bool,
 	       MapCoordReference, G3Timestream::TimestreamUnits,
-	       G3SkyMap::MapPolType, G3SkyMap::MapPolConv>(
+	       G3SkyMap::MapPolType, bool, G3SkyMap::MapPolConv>(
 		  (bp::arg("data"),
 		   bp::arg("weighted") = true,
 		   bp::arg("nested") = false,
 		   bp::arg("coord_ref") = MapCoordReference::Equatorial,
 		   bp::arg("units") = G3Timestream::Tcmb,
 		   bp::arg("pol_type") = G3SkyMap::None,
+		   bp::arg("shift_ra") = false,
 		   bp::arg("pol_conv") = G3SkyMap::ConvNone),
 	       "Instantiate a Healpix map from existing data. If the data are "
 	       "a single numpy array, assumes this is a dense map. Otherwise, "

--- a/maps/tests/healpix_maps.py
+++ b/maps/tests/healpix_maps.py
@@ -15,6 +15,15 @@ assert(x.npix_allocated == 1500)
 assert(x[1499] == 1499)
 assert(x[1501] == 0)
 
+# check attributes
+attrs = ["nside", "res", "nested", "shift_ra", "units", "pol_type", "pol_conv", "coord_ref", "weighted"]
+xc = x.clone()
+for attr in attrs:
+    assert getattr(xc, attr) == getattr(x, attr), "Attribute {} mismatched on clone()".format(attr)
+xc = x.clone(False)
+for attr in attrs:
+    assert getattr(xc, attr) == getattr(x, attr), "Attribute {} mismatched on clone(False)".format(attr)
+
 # Test conversion between representations is lossless
 # Along the way, test nonzero_pixels() and rebin() once for each
 # representation.
@@ -51,6 +60,15 @@ assert(x2[0] == v0)
 assert(np.sum(x2) == np.sum(v))
 
 x.shift_ra = True
+
+# check attributes
+xc = x.clone()
+for attr in attrs:
+    assert getattr(xc, attr) == getattr(x, attr), "Attribute {} mismatched on clone()".format(attr)
+xc = x.clone(False)
+for attr in attrs:
+    assert getattr(xc, attr) == getattr(x, attr), "Attribute {} mismatched on clone(False)".format(attr)
+
 x.ringsparse = True # Indexed to ring
 assert(x.nside == 64)
 assert(x.npix_allocated == 1512) # shifted ringsparse is less efficient
@@ -128,7 +146,6 @@ ki = np.asarray(ki)[ii]
 vi = np.asarray(vi)[ii]
 assert((ki == kr).all())
 assert((vi == vr).all())
-
 
 # Conversion to/from flatsky maps
 fm_stub = maps.FlatSkyMap(


### PR DESCRIPTION
Ensure that all constructors have the same signature.  Also add some tests to check that attributes are properly copied on `clone()`.