### PR TITLE
Add G3Constants namespace and python bindings

### DIFF
--- a/core/include/core/G3Constants.h
+++ b/core/include/core/G3Constants.h
@@ -5,32 +5,25 @@
 #include <G3Units.h>
 
 namespace G3Constants {
-	using namespace G3Units;
-
-	/* Math */
-	const double pi = M_PI;
-	const double twopi = 2.0 * M_PI;
-	const double halfpi = M_PI / 2.0;
-
 	/* Speed of light */
-	const double c = 299792458.0 * m / s;
+	const double c = 299792458.0 * G3Units::m / G3Units::s;
 
 	/* Planck constant */
-	const double h = 6.62607015e-34 * W * s * s;
+	const double h = 6.62607015e-34 * G3Units::W * G3Units::s * G3Units::s;
 	const double hbar = h / 2.0 / pi;
 
 	/* Boltzmann constant */
-	const double k = 1.380649e-23 * W * s / K;
+	const double k = 1.380649e-23 * G3Units::W * G3Units::s / G3Units::K;
 	const double kb = k;
 
 	/* Newtonian gravitational constant */
-	const double G = 6.6743e-11 * m * m * m / kg / s / s;
+	const double G = 6.6743e-11 * G3Units::m * G3Units::m * G3Units::m / G3Units::kg / G3Units::s / G3Units::s;
 
 	/* Standard gravitational acceleration */
-	const double g0 = 9.80665 * m / s / s;
+	const double g0 = 9.80665 * G3Units::m / G3Units::s / G3Units::s;
 
 	/* Elementary charge */
-	const double e = 1.602176634e-19 * A * s;
+	const double e = 1.602176634e-19 * G3Units::A * G3Units::s;
 }
 
 #endif

--- a/core/include/core/G3Constants.h
+++ b/core/include/core/G3Constants.h
@@ -1,0 +1,36 @@
+#ifndef _G3_CONSTANTS_H
+#define _G3_CONSTANTS_H
+
+#include <cmath>
+#include <G3Units.h>
+
+namespace G3Constants {
+	using namespace G3Units;
+
+	/* Math */
+	const double pi = M_PI;
+	const double twopi = 2.0 * M_PI;
+	const double halfpi = M_PI / 2.0;
+
+	/* Speed of light */
+	const double c = 299792458.0 * m / s;
+
+	/* Planck constant */
+	const double h = 6.62607015e-34 * W * s * s;
+	const double hbar = h / 2.0 / pi;
+
+	/* Boltzmann constant */
+	const double k = 1.380649e-23 * W * s / K;
+	const double kb = k;
+
+	/* Newtonian gravitational constant */
+	const double G = 6.6743e-11 * m * m * m / kg / s / s;
+
+	/* Standard gravitational acceleration */
+	const double g0 = 9.80665 * m / s / s;
+
+	/* Elementary charge */
+	const double e = 1.602176634e-19 * A * s;
+}
+
+#endif

--- a/core/include/core/G3Constants.h
+++ b/core/include/core/G3Constants.h
@@ -10,7 +10,7 @@ namespace G3Constants {
 
 	/* Planck constant */
 	const double h = 6.62607015e-34 * G3Units::W * G3Units::s * G3Units::s;
-	const double hbar = h / 2.0 / pi;
+	const double hbar = h / 2.0 / M_PI;
 
 	/* Boltzmann constant */
 	const double k = 1.380649e-23 * G3Units::W * G3Units::s / G3Units::K;

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -11,6 +11,7 @@
 #include <G3Pipeline.h>
 #include <G3Timestream.h>
 #include <G3SimpleLoggers.h>
+#include <G3Constants.h>
 
 namespace bp = boost::python;
 
@@ -242,6 +243,15 @@ BOOST_PP_SEQ_FOR_EACH(UNITS_INTERFACE,~,UNITS)
   .add_static_property(BOOST_PP_STRINGIZE(T), &BOOST_PP_CAT(g3units_return_, T))
 struct __XXX_fake_g3units_namespace_XXX {};
 
+#define CONSTANTS (pi)(twopi)(halfpi)(c)(h)(hbar)(k)(kb)(G)(g0)(e)
+
+#define CONSTANTS_INTERFACE(r,data,T) \
+  static double BOOST_PP_CAT(g3constants_return_,T)() { return G3Constants::T; }
+BOOST_PP_SEQ_FOR_EACH(CONSTANTS_INTERFACE,~,CONSTANTS)
+#define G3_CONSTANTS_DEF(r,data,T) \
+  .add_static_property(BOOST_PP_STRINGIZE(T), &BOOST_PP_CAT(g3constants_return_, T))
+struct __XXX_fake_g3constants_namespace_XXX {};
+
 // Nonsense boilerplate for POD vector numpy bindings
 #define numpy_vector_infrastructure(T, name, conv) \
 template <> \
@@ -366,6 +376,13 @@ BOOST_PYTHON_MODULE(core)
 	    "units arguments to functions. 1 second is 1*G3Units.s.",
 	    bp::no_init)
 	      BOOST_PP_SEQ_FOR_EACH(G3_UNITS_DEF,~,UNITS);
+
+	// Constants values
+	bp::class_<__XXX_fake_g3constants_namespace_XXX, boost::noncopyable>(
+	  "G3Constants",
+	    "Mathematical and physical constants in G3Units.",
+	    bp::no_init)
+	      BOOST_PP_SEQ_FOR_EACH(G3_CONSTANTS_DEF,~,CONSTANTS);
 
 	// Some POD types
 	register_vector_of<bool>("Bool");

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -243,7 +243,7 @@ BOOST_PP_SEQ_FOR_EACH(UNITS_INTERFACE,~,UNITS)
   .add_static_property(BOOST_PP_STRINGIZE(T), &BOOST_PP_CAT(g3units_return_, T))
 struct __XXX_fake_g3units_namespace_XXX {};
 
-#define CONSTANTS (pi)(twopi)(halfpi)(c)(h)(hbar)(k)(kb)(G)(g0)(e)
+#define CONSTANTS (c)(h)(hbar)(k)(kb)(G)(g0)(e)
 
 #define CONSTANTS_INTERFACE(r,data,T) \
   static double BOOST_PP_CAT(g3constants_return_,T)() { return G3Constants::T; }


### PR DESCRIPTION
This commit provides a set of common mathematical and physical constants, stored
in G3Units, for use in creating code with consistent units handling.