### PR TITLE
Include G3Units.h only where necessary

### DIFF
--- a/calibration/src/BoloProperties.cxx
+++ b/calibration/src/BoloProperties.cxx
@@ -1,4 +1,5 @@
 #include <pybindings.h>
+#include <G3Units.h>
 #include <calibration/BoloProperties.h>
 #include <container_pybindings.h>
 

--- a/core/include/core/G3.h
+++ b/core/include/core/G3.h
@@ -7,8 +7,6 @@
 #include <cereal/cereal.hpp>
 #include <cereal/types/polymorphic.hpp>
 
-#include <G3Units.h>
-
 #define G3_POINTERS(x) \
 typedef boost::shared_ptr<x> x##Ptr; \
 typedef boost::shared_ptr<const x> x##ConstPtr; \

--- a/core/src/G3Quat.cxx
+++ b/core/src/G3Quat.cxx
@@ -2,6 +2,7 @@
 #include <container_pybindings.h>
 #include <G3Quat.h>
 #include <G3Map.h>
+#include <G3Units.h>
 
 // Quaternion utilities
 

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -1,6 +1,7 @@
 #include <pybindings.h>
 #include <serialization.h>
 #include <G3Timestream.h>
+#include <G3Units.h>
 #include <std_map_indexing_suite.hpp>
 #include <boost/python/slice.hpp>
 

--- a/dfmux/include/dfmux/DfMuxBuilder.h
+++ b/dfmux/include/dfmux/DfMuxBuilder.h
@@ -4,6 +4,7 @@
 #include <deque>
 #include <unordered_map>
 #include <G3EventBuilder.h>
+#include <G3Units.h>
 
 #include <dfmux/DfMuxCollector.h>
 

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <pybindings.h>
+#include <G3Units.h>
 #include <dfmux/Housekeeping.h>
 
 #include <container_pybindings.h>

--- a/gcp/src/ACUStatus.cxx
+++ b/gcp/src/ACUStatus.cxx
@@ -1,6 +1,7 @@
 #include <pybindings.h>
 #include <serialization.h>
 #include <container_pybindings.h>
+#include <G3Units.h>
 #include <gcp/ACUStatus.h>
 
 template <class A> void ACUStatus::serialize(A &ar, unsigned v)

--- a/gcp/src/ARCFileReader.cxx
+++ b/gcp/src/ARCFileReader.cxx
@@ -5,6 +5,7 @@
 #include <G3Map.h>
 #include <G3Vector.h>
 #include <G3Data.h>
+#include <G3Units.h>
 #include <dataio.h>
 #include <gcp/Experiments.h>
 

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -6,6 +6,7 @@
 #include <sys/endian.h>
 #endif
 
+#include <G3Units.h>
 #include <maps/HealpixSkyMap.h>
 #include <maps/chealpix.h>
 

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -8,6 +8,7 @@
 #include <G3Quat.h>
 #include <G3Data.h>
 #include <G3Map.h>
+#include <G3Units.h>
 #include <maps/G3SkyMap.h>
 #include <maps/pointing.h>
 #include <calibration/BoloProperties.h>

--- a/maps/src/MapMockObserver.cxx
+++ b/maps/src/MapMockObserver.cxx
@@ -8,6 +8,7 @@
 #include <G3Quat.h>
 #include <G3Data.h>
 #include <G3Map.h>
+#include <G3Units.h>
 #include <maps/G3SkyMap.h>
 #include <maps/pointing.h>
 #include <calibration/BoloProperties.h>


### PR DESCRIPTION
This PR removes the `G3Units.h` header dependency from `G3.h`, and instead requires that it be explicitly `#include`'ed in all necessary source files.  This avoids having to rebuild the entire code base every time this header file is changed.