### PR TITLE
core/python.cxx: disambiguate something for gcc 11.1

### DIFF
--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -60,7 +60,7 @@ struct g3frame_picklesuite : boost::python::pickle_suite
 		std::vector<char> buffer;
 		boost::iostreams::filtering_ostream os(
 		    boost::iostreams::back_inserter(buffer));
-		bp::extract<const G3Frame &>(obj)().save(os);
+		(bp::extract<const G3Frame &>(obj))().save(os);
 		os.flush();
 
 		return boost::python::make_tuple(obj.attr("__dict__"),
@@ -78,7 +78,7 @@ struct g3frame_picklesuite : boost::python::pickle_suite
 
 		std::vector<char> buf((char *)view.buf, (char *)view.buf + view.len);
 		bp::extract<bp::dict>(obj.attr("__dict__"))().update(state[0]);
-		bp::extract<G3Frame &>(obj)().load(buf);
+		(bp::extract<G3Frame &>(obj))().load(buf);
 		PyBuffer_Release(&view);
 	}
 };


### PR DESCRIPTION
This fixes a warning -> error when using gcc 11.1.0.  Should be otherwise innocuous.
```
/path/to/spt3g_software/core/src/python.cxx:62:50: error: empty parentheses were disambiguated as a function declaration [-Werror=vexing-parse]
   62 |                 bp::extract<const G3Frame &>(obj)().save(os);
      |                                                  ^~
```