### PR TITLE
Improvements to MapMockObserver

### DIFF
--- a/maps/python/quathelpers.py
+++ b/maps/python/quathelpers.py
@@ -78,6 +78,9 @@ def AddTimingToPointingQuats(fr, key, timing_ref='RawBoresightAz'):
     if key not in fr:
         return
 
+    if isinstance(fr[key], G3TimestreamQuat):
+        return
+
     x = fr.pop(key)
     x = G3TimestreamQuat(x)
     x.start = fr[timing_ref].start


### PR DESCRIPTION
This PR ports several simulation features from the SPT-3G private repository into the `MapMockObserver` module.  Namely:

 * An option to sample the input map by interpolation
 * ~An option to construct the output timestreams using a `G3VectorString` of detector names found in the same frame.~ Removed.