### PR TITLE
Memory efficient map masking utilities

### DIFF
--- a/maps/include/maps/maputils.h
+++ b/maps/include/maps/maputils.h
@@ -8,7 +8,7 @@
 #include <maps/G3SkyMap.h>
 #include <maps/FlatSkyMap.h>
 
-G3SkyMapPtr GetMaskMap(G3SkyMapConstPtr m);
+G3SkyMapPtr GetMaskMap(G3SkyMapConstPtr m, bool ignore_nans=false, bool ignore_infs=false);
 
 void RemoveWeightsT(G3SkyMapPtr T, G3SkyMapWeightsConstPtr W, bool zero_nans = false);
 void RemoveWeights(G3SkyMapPtr T, G3SkyMapPtr Q, G3SkyMapPtr U, G3SkyMapWeightsConstPtr W,
@@ -23,10 +23,11 @@ void ReprojMap(G3SkyMapConstPtr in_map, G3SkyMapPtr out_map, int rebin=1, bool i
 
 void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, double h=0.001, bool invert=false);
 
-std::vector<double> GetMapStats(G3SkyMapConstPtr m, int order=2,
+std::vector<double> GetMapStats(G3SkyMapConstPtr m, G3SkyMapConstPtr mask, int order=2,
     bool ignore_zeros=false, bool ignore_nans=false);
 
-double GetMapMedian(G3SkyMapConstPtr m, bool ignore_zeros=false, bool ignore_nans=false);
+double GetMapMedian(G3SkyMapConstPtr m, G3SkyMapConstPtr mask,
+    bool ignore_zeros=false, bool ignore_nans=false);
 
 FlatSkyMapPtr ConvolveMap(FlatSkyMapConstPtr map, FlatSkyMapConstPtr kernel);
 

--- a/maps/include/maps/maputils.h
+++ b/maps/include/maps/maputils.h
@@ -8,7 +8,9 @@
 #include <maps/G3SkyMap.h>
 #include <maps/FlatSkyMap.h>
 
-G3SkyMapPtr GetMaskMap(G3SkyMapConstPtr m, bool ignore_nans=false, bool ignore_infs=false);
+G3SkyMapPtr GetMaskMap(G3SkyMapConstPtr m, bool zero_nans=false, bool zero_infs=false);
+
+G3SkyMapPtr ApplyMask(G3SkyMapPtr m, G3SkyMapConstPtr mask, bool inverse=false);
 
 void RemoveWeightsT(G3SkyMapPtr T, G3SkyMapWeightsConstPtr W, bool zero_nans = false);
 void RemoveWeights(G3SkyMapPtr T, G3SkyMapPtr Q, G3SkyMapPtr U, G3SkyMapWeightsConstPtr W,
@@ -19,15 +21,18 @@ void ApplyWeights(G3SkyMapPtr T, G3SkyMapPtr Q, G3SkyMapPtr U, G3SkyMapWeightsCo
 
 boost::python::tuple GetRaDecMap(G3SkyMapConstPtr m);
 
+G3SkyMapPtr GetRaDecMask(G3SkyMapConstPtr m, double ra_left, double ra_right,
+    double dec_bottom, double dec_top);
+
 void ReprojMap(G3SkyMapConstPtr in_map, G3SkyMapPtr out_map, int rebin=1, bool interp=false);
 
 void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, double h=0.001, bool invert=false);
 
-std::vector<double> GetMapStats(G3SkyMapConstPtr m, G3SkyMapConstPtr mask, int order=2,
-    bool ignore_zeros=false, bool ignore_nans=false);
+std::vector<double> GetMapStats(G3SkyMapConstPtr m, G3SkyMapConstPtr mask=NULL, int order=2,
+    bool ignore_zeros=false, bool ignore_nans=false, bool ignore_infs=false);
 
-double GetMapMedian(G3SkyMapConstPtr m, G3SkyMapConstPtr mask,
-    bool ignore_zeros=false, bool ignore_nans=false);
+double GetMapMedian(G3SkyMapConstPtr m, G3SkyMapConstPtr mask=NULL,
+    bool ignore_zeros=false, bool ignore_nans=false, bool ignore_infs=false);
 
 FlatSkyMapPtr ConvolveMap(FlatSkyMapConstPtr map, FlatSkyMapConstPtr kernel);
 

--- a/maps/include/maps/maputils.h
+++ b/maps/include/maps/maputils.h
@@ -8,34 +8,65 @@
 #include <maps/G3SkyMap.h>
 #include <maps/FlatSkyMap.h>
 
+// Return a map that is set to one where the input map is non-zero.
+// Optionally zero out nans and/or infs if zero_nans or zero_infs is true.
 G3SkyMapPtr GetMaskMap(G3SkyMapConstPtr m, bool zero_nans=false, bool zero_infs=false);
 
-G3SkyMapPtr ApplyMask(G3SkyMapPtr m, G3SkyMapConstPtr mask, bool inverse=false);
+// Zero out any values in the input map where the mask is zero
+// If inverse is true, zero the input map where the mask is non-zero
+void ApplyMask(G3SkyMapPtr m, G3SkyMapConstPtr mask, bool inverse=false);
 
+// Divide out map weights from the sky maps
 void RemoveWeightsT(G3SkyMapPtr T, G3SkyMapWeightsConstPtr W, bool zero_nans = false);
 void RemoveWeights(G3SkyMapPtr T, G3SkyMapPtr Q, G3SkyMapPtr U, G3SkyMapWeightsConstPtr W,
     bool zero_nans = false);
 
+// Apply map weights to sky maps
 void ApplyWeightsT(G3SkyMapPtr T, G3SkyMapWeightsConstPtr W);
 void ApplyWeights(G3SkyMapPtr T, G3SkyMapPtr Q, G3SkyMapPtr U, G3SkyMapWeightsConstPtr W);
 
+// Return maps of RA and Dec coordinates for each pixel in the input map
 boost::python::tuple GetRaDecMap(G3SkyMapConstPtr m);
 
+// Return a mask that is one for all pixels in the input map that are within the
+// given ra and dec rectangular bounds, and zero otherwise
 G3SkyMapPtr GetRaDecMask(G3SkyMapConstPtr m, double ra_left, double ra_right,
     double dec_bottom, double dec_top);
 
+// Reproject the input map onto the output map grid, optionally
+// oversampling the output pixels by the rebin factor, and/or sampling the input map
+// with interpolation
 void ReprojMap(G3SkyMapConstPtr in_map, G3SkyMapPtr out_map, int rebin=1, bool interp=false);
 
+// Flatten or unflatten Q and U polarization maps using the polarization gradient across the map.
+// The h parameter controls the pixel width over which a gradient is computed.
 void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, double h=0.001, bool invert=false);
 
+// Compute map moments up to fourth order (mean, var, skewness, kurtosis) of the input map,
+// optionally excluding any pixels that are zero in the input mask, or zero/nan/inf in the input map
 std::vector<double> GetMapStats(G3SkyMapConstPtr m, G3SkyMapConstPtr mask=NULL, int order=2,
     bool ignore_zeros=false, bool ignore_nans=false, bool ignore_infs=false);
 
+// Compute the median of the input map, optionally excluding any pixels that are
+// zero in the input mask, or zero/nan/inf in the input map
 double GetMapMedian(G3SkyMapConstPtr m, G3SkyMapConstPtr mask=NULL,
     bool ignore_zeros=false, bool ignore_nans=false, bool ignore_infs=false);
 
+// Compute the min and max of the values in the input map, optionally excluding
+// any pixels that are zero in the input mask, or zero/nan/inf in the input map
+std::vector<double> GetMapMinMax(G3SkyMapConstPtr m, G3SkyMapConstPtr mask=NULL,
+    bool ignore_zeros=false, bool ignore_nans=false, bool ignore_infs=false);
+
+// Compute the histogram of the input map pixels, grouping the values into bins
+// defined by the array of bin edges, and optionally excluding any pixels that are
+// zero in the input mask, or zero/nan/inf in the input map
+std::vector<double> GetMapHist(G3SkyMapConstPtr m, const std::vector<double> &bin_edges,
+    G3SkyMapConstPtr mask, bool ignore_zeros, bool ignore_nans, bool ignore_infs);
+
+// Convolve the input flat sky map with a filter kernel
 FlatSkyMapPtr ConvolveMap(FlatSkyMapConstPtr map, FlatSkyMapConstPtr kernel);
 
+// Python bindings
 void maputils_pybindings(void);
 
 #endif //_MAPS_MAPUTILS_H

--- a/maps/src/maputils.cxx
+++ b/maps/src/maputils.cxx
@@ -42,7 +42,7 @@ G3SkyMapPtr ApplyMask(G3SkyMapPtr m, G3SkyMapConstPtr mask, bool inverse)
 	g3_assert(m->IsCompatible(*mask));
 
 	for (size_t i = 0; i < m->size(); i++) {
-		if (!!(m->at(i)))
+		if (!(m->at(i)))
 			continue;
 		if (!!(mask->at(i)) == inverse)
 			(*m)[i] = 0;


### PR DESCRIPTION
* Options for ignoring non-finite values in creating a mask (0/1 valued map) from an input map.
* Option for selecting pixels from a mask in computing map statistics
* New ApplyMask function for applying a mask to a map in-place, with the option to invert the mask.  This is particularly useful for, e.g., cutting out point source masked holes in a rectangular mask without having to invert the entire point source mask in a memory-inefficient way, or for nulling out nan or inf values in a map.
* New GetRaDecMask function for creating a rectangular mask from ra/dec bounds.
* New GetMapMinMax function for computing the min and max values in the map, with optional masking of zero/nan/inf/out-of-bounds pixels
* New GetMapHist function for computing a histogram of the values in the map, with optional masking of zero/nan/inf/out-of-bounds pixels