### PR TITLE
Add boost dependency information to exported Spt3gConfig.cmake

### DIFF
--- a/cmake/Spt3gConfig.cmake.in
+++ b/cmake/Spt3gConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+set(Boost_PYTHON_TYPE @Boost_PYTHON_TYPE@)
+find_dependency(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
+
 set(SPT3G_SOURCE_DIR @CMAKE_SOURCE_DIR@)
 set(SPT3G_BUILD_DIR @CMAKE_BINARY_DIR@)
 set(SPT3G_INCLUDE_INSTALL_DIR @PACKAGE_INCLUDE_INSTALL_DIR@)


### PR DESCRIPTION
This makes a small change to the input Spt3gConfig.cmake.in file
to include the exported boost package info.  Without this,
external code that uses Spt3gConfig.cmake cannot resolve the
Boost linking dependency.  Thanks to Sasha for helping me sort
this out.