### PR TITLE
Add gcp.ARCFile class analogous to core.G3File

### DIFF
--- a/core/python/util.py
+++ b/core/python/util.py
@@ -40,6 +40,26 @@ def Dump(frame, type=None, added_message = None):
 
 
 @indexmod
+class InjectFrame(object):
+    """
+    Inject an arbitrary frame into a pipeline.
+
+    Arguments
+    ---------
+    frame : G3Frame
+        The frame to inject
+    """
+    def __init__(self, frame):
+        self.frame = frame
+    def __call__(self, frame):
+        if self.frame is None:
+            return
+        out = [self.frame, frame]
+        self.frame = None
+        return out
+
+
+@indexmod
 def InjectDebug(frame, type=None, debug_start_func = None):
     '''starts a pdb session when a frame of type shows up.
 

--- a/gcp/python/ARCFile.py
+++ b/gcp/python/ARCFile.py
@@ -1,0 +1,39 @@
+from spt3g.gcp import ARCFileReader, ARCExtract
+
+class ARCFile(object):
+    '''Iterable class for ARC files, as created by GCP. Loop through frames by doing something like:
+    f = gcp.ARCFile('/path/to/arc.dat')
+    for frame in f:
+        print( frame )
+
+    An entire file can also be read into an indexable list by doing:
+    f = list(gcp.ARCFile('/path/to/arc.dat'))
+    '''
+    def __init__(self, path, extract=False):
+        self.reader = ARCFileReader(path)
+        self.extract = extract
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        frames = self.reader.Process(None)
+        if len(frames) == 0:
+            raise StopIteration('No more frames in file')
+        if len(frames) > 1:
+            raise ValueError('Too many frames returned by reader')
+        frame = frames[0]
+
+        if self.extract:
+            # calibrate and parse arc frames
+            from spt3g.core import G3Pipeline, G3InfiniteSource, InjectFrame
+
+            pipe = G3Pipeline()
+            pipe.Add(G3InfiniteSource, n=1)
+            pipe.Add(InjectFrame, frame=frame)
+            pipe.Add(ARCExtract)
+            pipe.Run()
+
+        return frame
+
+    __next__ = next

--- a/gcp/python/__init__.py
+++ b/gcp/python/__init__.py
@@ -5,3 +5,4 @@ from .ARCExtractor import UnpackACUData, UnpackTrackerData, DecryptFeatureBit, A
 from .ARCHKExtractor import UnpackSPTpolHKData
 from .GCPDataTee import GCPHousekeepingTee, GCPSignalledHousekeeping, GCPBoloDataTee, PagerWatchdog, DAQWatchdog
 from .InfluxDB import UpdateDB
+from .ARCFile import ARCFile


### PR DESCRIPTION
Optional `extract` keyword argument to also run `gcp.ARCExtract` on each frame.

Also, add a `core.InjectFrame` utility function for injecting arbitrary frames into a pipeline, used with `gcp.ARCFile(..., extract=True)`.