### PR TITLE
Add seek and tell functions from so3g.G3IndexedReader

### DIFF
--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -15,6 +15,8 @@ public:
                  float timeout = -1.);
 
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
+	int Seek(int offset);
+	int Tell();
 
 private:
 	void StartFile(std::string path);

--- a/core/tests/fileio.py
+++ b/core/tests/fileio.py
@@ -1,23 +1,34 @@
 #!/usr/bin/env python
 
 from spt3g import core
-import time, sys
+import time
 
 # File to disk
 pipe = core.G3Pipeline()
 pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Timepoint, n=10)
+# Drop a wiring frame in the middle
+count = 0
+def addwiring(fr):
+    global count
+    if fr.type == core.G3FrameType.Timepoint:
+        count += 1
+        if count == 6:
+            fr2 = core.G3Frame(core.G3FrameType.Wiring)
+            return [fr2, fr]
+pipe.Add(addwiring)
 n = 0
 def addinfo(fr):
-	global n
-	if fr.type != core.G3FrameType.Timepoint:
-		return
-	fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
-	fr['count'] = n
-	n += 1
+    global n
+    if fr.type != core.G3FrameType.Timepoint:
+        return
+    fr['time'] = core.G3Time(int(time.time()*core.G3Units.s))
+    fr['count'] = n
+    n += 1
 pipe.Add(addinfo)
 pipe.Add(core.Dump)
 pipe.Add(core.G3Writer, filename='test.g3')
 pipe.Run()
+assert n == 10, 'Wrong number of frames written (%d should be %d)' % (n, 10)
 
 # And back from disk
 print('Reading')
@@ -26,22 +37,67 @@ pipe.Add(core.G3Reader, filename='test.g3')
 pipe.Add(core.Dump)
 n = 0
 def checkinfo(fr):
-	global n
-	if fr.type != core.G3FrameType.Timepoint:
-		return
-	if 'time' not in fr:
-		print('No time key in frame')
-		sys.exit(1)
-	if fr['count'] != n:
-		print('Out of order frame')
-		sys.exit(1)
-	n += 1
+    global n
+    if fr.type != core.G3FrameType.Timepoint:
+        return
+    assert 'time' in fr, 'No time key in frame'
+    assert fr['count'] == n, 'Out of order frame'
+    n += 1
 pipe.Add(checkinfo)
 pipe.Run()
 
-if n != 10:
-	print('Wrong number of frames (%d should be %d)' % (n, 10))
-	sys.exit(1)
+assert n == 10, 'Wrong number of frames read (%d should be %d)' % (n, 10)
 
-sys.exit(0)
+# Indexing
+class CachingReader:
+    def __init__(self, filename='test.g3'):
+        self.reader = core.G3Reader(filename='test.g3')
+        self.w_pos = None
 
+    def __call__(self, frame):
+        assert frame is None
+        pos = self.reader.tell()
+        fr = self.reader(frame)
+        if not len(fr):
+            return fr
+        if fr[0].type == core.G3FrameType.Wiring:
+            self.w_pos = pos
+        return fr
+
+cacher = CachingReader()
+
+pipe = core.G3Pipeline()
+pipe.Add(cacher)
+pipe.Add(core.Dump)
+pipe.Run()
+
+assert cacher.w_pos is not None, 'Missing wiring frame'
+
+# Using cached index
+class CachedReader:
+    def __init__(self, filename='test.g3', start=None):
+        self.reader = core.G3Reader(filename=filename)
+        self.pos = start
+
+    def __call__(self, frame):
+        assert frame is None
+        if self.pos is not None:
+            self.reader.seek(self.pos)
+        if self.pos is not None:
+            assert self.reader.tell() == self.pos
+        fr = self.reader(frame)
+        if not len(fr):
+            return fr
+        if self.pos is not None:
+            assert fr[0].type == core.G3FrameType.Wiring
+            self.pos = None
+        return fr
+
+cached = CachedReader(start=cacher.w_pos)
+
+pipe = core.G3Pipeline()
+pipe.Add(cached)
+pipe.Add(core.Dump)
+pipe.Run()
+
+assert cached.pos is None, "Missing wiring frame"


### PR DESCRIPTION
This PR provides an implementation for seeking through a G3 file for positions of particular frames, allowing faster parsing of data after the initial pass.  Most efficient for streams containing many interleaved frame types.

Includes a test of the functionality using two passes through an existing data file, first to cache the desired frame position, and then to seek to that position.