### PR TITLE
More efficient ARC frame calibration

### DIFF
--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -89,12 +89,17 @@ class CalibrateFrame:
 
         for board in frame.keys():
             cboard = frame.pop(board)
+            if board not in self.cal:
+                continue
+            bcal = self.cal[board]
             for rmap, crmap in cboard.items():
+                if rmap not in cd:
+                    continue
+                rcal = bcal[rmap]
                 for reg, creg in crmap.items():
-                    try:
-                        rcd = self.cal[board][rmap][reg]
-                    except KeyError:
+                    if reg not in self.cal[board][rmap]:
                         continue
+                    rcd = rcal[reg]
                     rsize = np.size(creg)
                     rshape = np.shape(creg)
                     if rsize > 1 and len(rshape) > 1:
@@ -103,13 +108,13 @@ class CalibrateFrame:
                                 rcdi = rcd[i]
                             except KeyError:
                                 rcdi = rcd
-                            cboard[rmap][reg][i] = CalibrateValue(creg[i], rcdi)
+                            creg[i] = CalibrateValue(creg[i], rcdi)
                     else:
                         try:
                             rcdi = rcd[0]
                         except KeyError:
                             rcdi = rcd
-                        cboard[rmap][reg] = CalibrateValue(creg, rcdi)
+                        crmap[reg] = CalibrateValue(creg, rcdi)
             frame[board] = cboard
 
         frame['Calibrated'] = True

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -61,13 +61,12 @@ def CalibrateValue(data, caldict_entry):
     if np.size(data) == 1:
         data = data.value
     data2 = np.array(data, dtype='float64')
-    thisdtype = data2.dtype
 
     # calibrate units
     offset, recip = caldict_entry['Offset'], caldict_entry['ReciprocalFactor']
     if offset != 0:
-        data2 += np.array(offset, dtype=thisdtype)
-    data2 *= np.array(uvalue / recip, dtype=thisdtype)
+        data2 += float(offset)
+    data2 *= float(uvalue / recip)
     if not data2.shape:
         data2 = data2.tolist()
 

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -97,7 +97,7 @@ class CalibrateFrame:
                     continue
                 rcal = bcal[rmap]
                 for reg, creg in crmap.items():
-                    if reg not in self.cal[board][rmap]:
+                    if reg not in rcal:
                         continue
                     rcd = rcal[reg]
                     rsize = np.size(creg)

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -41,7 +41,22 @@ def CalibrateValue(data, caldict_entry):
     '''Apply gain / offset units from G3 cal file to register'''
 
     uvalue = UnitValue(caldict_entry)
-    g3type = type(data)
+
+    # if a register has units, it can't be an int anymore.  well, actually,
+    # it can't be an int if we're adding floats to it or multiplying it by
+    # floats either, so convert everything that has an entry in the cal file
+    # to float/double.
+    if 'OutputType' not in caldict_entry:
+        g3type = type(data)
+        if g3type == core.G3VectorInt:
+            g3type = core.G3VectorDouble
+        elif g3type == core.G3MapInt:
+            g3type = core.G3MapDouble
+        elif g3type == core.G3Int:
+            g3type = core.G3Double
+        caldict_entry['OutputType'] = g3type
+    g3type = caldict_entry['OutputType']
+
     # make a copy
     if np.size(data) == 1:
         data = data.value
@@ -56,18 +71,7 @@ def CalibrateValue(data, caldict_entry):
     if not data2.shape:
         data2 = data2.tolist()
 
-    # if a register has units, it can't be an int anymore.  well, actually,
-    # it can't be an int if we're adding floats to it or multiplying it by
-    # floats either, so convert everything that has an entry in the cal file
-    # to float/double.
-    if g3type == core.G3VectorInt:
-        return core.G3VectorDouble(data2)
-    elif g3type == core.G3MapInt:
-        return core.G3MapDouble(data2)
-    elif g3type == core.G3Int:
-        return core.G3Double(data2)
-    else:
-        return g3type(data2)
+    return g3type(data2)
 
 
 @core.indexmod

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -93,7 +93,7 @@ class CalibrateFrame:
                 continue
             bcal = self.cal[board]
             for rmap, crmap in cboard.items():
-                if rmap not in cd:
+                if rmap not in bcal:
                     continue
                 rcal = bcal[rmap]
                 for reg, creg in crmap.items():

--- a/gcp/python/ARCExtractor.py
+++ b/gcp/python/ARCExtractor.py
@@ -60,7 +60,7 @@ def CalibrateValue(data, caldict_entry):
     # make a copy
     if np.size(data) == 1:
         data = data.value
-    data2 = np.array(data, dtype='float64')
+    data2 = np.asarray(data, dtype='float64')
 
     # calibrate units
     offset, recip = caldict_entry['Offset'], caldict_entry['ReciprocalFactor']


### PR DESCRIPTION
 * Read and parse GCP calibration file
 * Avoid unnecessary wholesale copies of boards

This should reduce execution time of this code by a significant margin.