### PR TITLE
G3SkyMap API Improvements

### DIFF
--- a/maps/include/maps/FlatSkyMap.h
+++ b/maps/include/maps/FlatSkyMap.h
@@ -81,8 +81,7 @@ public:
 
 	template <class A> void load(A &ar, unsigned v);
 	template <class A> void save(A &ar, unsigned v) const;
-	void FillFromArray(boost::python::object v);
-	G3SkyMapPtr ArrayClone(boost::python::object v);
+	virtual void FillFromArray(boost::python::object v) override;
 	virtual G3SkyMapPtr Clone(bool copy_data = true) const override;
 	std::string Description() const override;
 

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -46,6 +46,8 @@ public:
 	virtual ~G3SkyMap() {};
 
 	// Reimplement the following in subclasses
+	virtual void FillFromArray(boost::python::object v) = 0;
+	boost::shared_ptr<G3SkyMap> ArrayClone(boost::python::object v) const;
 	virtual boost::shared_ptr<G3SkyMap> Clone(bool copy_data = true) const = 0;
 
 	MapCoordReference coord_ref;

--- a/maps/include/maps/HealpixSkyMap.h
+++ b/maps/include/maps/HealpixSkyMap.h
@@ -61,6 +61,7 @@ public:
 
 	template <class A> void load(A &ar, unsigned v);
 	template <class A> void save(A &ar, unsigned v) const;
+	virtual void FillFromArray(boost::python::object v) override;
 	virtual G3SkyMapPtr Clone(bool copy_data = true) const override;
 	std::string Description() const override;
 

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -99,6 +99,16 @@ G3SkyMap::G3SkyMap(MapCoordReference coords, bool weighted,
 			 "Set the pol_conv attribute to IAU or COSMO.");
 }
 
+G3SkyMapPtr
+G3SkyMap::ArrayClone(boost::python::object val) const
+{
+
+	G3SkyMapPtr skymap = Clone(false);
+	skymap->FillFromArray(val);
+	return skymap;
+}
+
+
 G3SkyMapWeights::G3SkyMapWeights(G3SkyMapConstPtr ref, bool polarized) :
     TT(ref->Clone(false)), TQ(polarized ? ref->Clone(false) : NULL),
     TU(polarized ? ref->Clone(false) : NULL),
@@ -943,6 +953,10 @@ PYBINDINGS("maps") {
 	      (bp::arg("copy_data")=true),
 	       "Return a map of the same type, populated with a copy of the data "
 	       "if the argument is true (default), empty otherwise.")
+	    .def("array_clone", &G3SkyMap::ArrayClone,
+	      (bp::arg("array")),
+	       "Return a map of the same type, populated with a copy of the input "
+	       "numpy array")
 	    .def("compatible", &G3SkyMap::IsCompatible,
 	      "Returns true if the input argument is a map with matching dimensions "
 	      "and boundaries on the sky.")

--- a/maps/tests/map_modules.py
+++ b/maps/tests/map_modules.py
@@ -1,79 +1,84 @@
 from spt3g import core, maps
 import numpy as np
 
-pipe = core.G3Pipeline()
+maplist = [
+    maps.FlatSkyMap(300, 300, core.G3Units.arcmin, proj=maps.MapProjection.ProjZEA),
+    maps.HealpixSkyMap(64),
+]
 
-m = maps.FlatSkyMap(300, 300, core.G3Units.arcmin, proj=maps.MapProjection.ProjZEA)
+for m in maplist:
 
-pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Observation, n=1)
-pipe.Add(maps.InjectMapStub, map_id="test_map", map_stub=m, polarized=False, weighted=True)
+    pipe = core.G3Pipeline()
 
-def RandomMap(frame):
-    if frame.type != core.G3FrameType.Map:
-        return
+    pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Observation, n=1)
+    pipe.Add(maps.InjectMapStub, map_id="test_map", map_stub=m, polarized=False, weighted=True)
 
-    tmap = frame.pop("T")
-    tmap[:] = np.random.randn(*m.shape)
-    frame["T"] = tmap
+    def RandomMap(frame):
+        if frame.type != core.G3FrameType.Map:
+            return
 
-    wmap = frame.pop("Wunpol")
-    wmap.TT[:] = 10 * np.ones(m.shape)
-    frame["Wunpol"] = wmap
+        tmap = frame.pop("T")
+        tmap[:] = np.random.randn(*m.shape)
+        frame["T"] = tmap
+
+        wmap = frame.pop("Wunpol")
+        wmap.TT[:] = 10 * np.ones(m.shape)
+        frame["Wunpol"] = wmap
 
 
-pipe.Add(RandomMap)
+    pipe.Add(RandomMap)
 
-mex0 = maps.ExtractMaps(copy=True)
-pipe.Add(mex0)
+    mex0 = maps.ExtractMaps(copy=True)
+    pipe.Add(mex0)
 
-pipe.Add(maps.MakeMapsPolarized)
-pipe.Add(maps.RemoveWeights)
-pipe.Add(maps.ApplyWeights)
+    pipe.Add(maps.MakeMapsPolarized)
+    pipe.Add(maps.RemoveWeights)
+    pipe.Add(maps.ApplyWeights)
 
-mex1 = maps.ExtractMaps()
-pipe.Add(mex1)
+    mex1 = maps.ExtractMaps()
+    pipe.Add(mex1)
 
-pipe.Add(
-    maps.ReplicateMaps,
-    input_map_id="test_map",
-    output_map_ids=["test_map1", "test_map2"],
-    copy_weights=True,
-)
+    pipe.Add(
+        maps.ReplicateMaps,
+        input_map_id="test_map",
+        output_map_ids=["test_map1", "test_map2"],
+        copy_weights=True,
+    )
 
-mex2 = maps.ExtractMaps()
-pipe.Add(mex2)
+    mex2 = maps.ExtractMaps()
+    pipe.Add(mex2)
 
-pipe.Add(maps.MakeMapsUnpolarized)
+    pipe.Add(maps.MakeMapsUnpolarized)
 
-mex3 = maps.ExtractMaps()
-pipe.Add(mex3)
+    mex3 = maps.ExtractMaps()
+    pipe.Add(mex3)
 
-tmap = m.array_clone(np.random.randn(*m.shape))
-tmap.pol_type = maps.MapPolType.T
-tmap.weighted = False
-pipe.Add(maps.InjectMaps, map_id="test_map", maps_in=[tmap])
+    tmap = m.array_clone(np.random.randn(*m.shape))
+    tmap.pol_type = maps.MapPolType.T
+    tmap.weighted = False
+    pipe.Add(maps.InjectMaps, map_id="test_map", maps_in=[tmap])
 
-pipe.Run()
+    pipe.Run()
 
-# check that mex0 and mex1 are nearly (but not exactly) identical
-assert np.max(mex0.maps["test_map"]["T"] - mex1.maps["test_map"]["T"]) != 0
-assert np.allclose(mex0.maps["test_map"]["T"], mex1.maps["test_map"]["T"])
+    # check that mex0 and mex1 are nearly (but not exactly) identical
+    assert np.max(mex0.maps["test_map"]["T"] - mex1.maps["test_map"]["T"]) != 0
+    assert np.allclose(mex0.maps["test_map"]["T"], mex1.maps["test_map"]["T"])
 
-# check that replication dropped the test map
-assert "test_map" not in mex2.maps
-assert "test_map" not in mex3.maps
+    # check that replication dropped the test map
+    assert "test_map" not in mex2.maps
+    assert "test_map" not in mex3.maps
 
-# check that replicated maps are properly populated
-for map_id in ["test_map1", "test_map2"]:
-    assert map_id in mex2.maps
-    assert map_id in mex3.maps
+    # check that replicated maps are properly populated
+    for map_id in ["test_map1", "test_map2"]:
+        assert map_id in mex2.maps
+        assert map_id in mex3.maps
 
-    mdict = mex2.maps[map_id]
-    for k in ["T", "Q", "U", "Wpol"]:
-        assert k in mdict
-        assert mdict[k].compatible(m)
+        mdict = mex2.maps[map_id]
+        for k in ["T", "Q", "U", "Wpol"]:
+            assert k in mdict
+            assert mdict[k].compatible(m)
 
-    mdict = mex3.maps[map_id]
-    for k in ["T", "Wunpol"]:
-        assert k in mdict
-        assert mdict[k].compatible(m)
+        mdict = mex3.maps[map_id]
+        for k in ["T", "Wunpol"]:
+            assert k in mdict
+            assert mdict[k].compatible(m)


### PR DESCRIPTION
Some improvements for interfacing skymaps with numpy arrays, mainly to fill in gaps in the HealpixSkyMap API.

* Promote `FlatSkyMap.ArrayClone` and `FlatSkyMap.FillFromArray` to the parent class
* Allow filling a healpix sky map with a numpy array using an empty slice (i.e. `m[:]`)