### PR TITLE
Area-preserving bilinear interpolation for Healpix maps

### DIFF
--- a/maps/README.rst
+++ b/maps/README.rst
@@ -88,11 +88,13 @@ Map values can be tested using ``.isnan(), .isinf(), .isfinite()`` methods as we
 Map Interpolation
 =================
 
-Several interpolation and rebinning utilities are provided.  The method ``G3SkyMap.get_interp_values`` can be used for extracting map values at arbitrary sky positions.  The method ``G3SkyMap.rebin`` can be used to downgrade the map resolution in a way that preserves the total power within each map pixel.
+Several interpolation and rebinning utilities are provided.  The method ``G3SkyMap.get_interp_values`` can be used for extracting map values at arbitrary sky positions using bilinear interpolation.  The method ``G3SkyMap.rebin`` can be used to downgrade the map resolution in a way that preserves the total power within each map pixel.
 
 The functions ``healpix_to_flatsky`` and ``flatsky_to_healpix`` functions are provided to reproject maps between flat sky and curved sky systems, with options to use interpolation or rebinning to improve the accuracy of the reprojection.
 
 The more general ``reproj_map`` function can also be used to convert between flat sky projections.
+
+*Note:* The interpolation routine for healpix maps produces results that differ from those of the equivalent ``healpy.get_interp_val`` routine.  The interpolation routine implemented here is area-preserving in the computation of bilinear weights, whereas the ``healpy`` routine is not.
 
 Map Weights
 ===========

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -350,7 +350,7 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 	}
 
 	if (ir1 == 0) {
-		double wz = z / z2;
+		double wz = (z - 1.0) / (z2 - 1.0);
 		weights[2] *= wz;
 		weights[3] *= wz;
 		double fac = (1 - wz) * 0.25;
@@ -361,7 +361,7 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 		pixels[0] = (pixels[2] + 2) & 3;
 		pixels[1] = (pixels[3] + 2) & 3;
 	} else if (ir2 == nring_) {
-		double wz = (z - z1) / (M_PI - z1);
+		double wz = (z - z1) / (-1.0 - z1);
 		weights[0] *= 1 - wz;
 		weights[1] *= 1 - wz;
 		double fac = wz * 0.25;

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -313,11 +313,11 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 	size_t ir1 = RingAbove(z);
 	size_t ir2 = ir1 + 1;
 
-	double theta1, theta2;
+	double z1, z2;
 
 	if (ir1 > 0) {
 		const HealpixRingInfo & ring = rings_[ir1];
-		theta1 = ring.theta;
+		z1 = ring.z;
 		double tmp = phi / ring.dphi - ring.shift;
 		long i1 = (tmp < 0) ? tmp - 1 : tmp;
 		double w1 = (phi - (i1 + ring.shift) * ring.dphi) / ring.dphi;
@@ -334,7 +334,7 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 
 	if (ir2 < nring_) {
 		const HealpixRingInfo & ring = rings_[ir2];
-		theta2 = ring.theta;
+		z2 = ring.z;
 		double tmp = phi / ring.dphi - ring.shift;
 		long i1 = (tmp < 0) ? tmp - 1 : tmp;
 		double w1 = (phi - (i1 + ring.shift) * ring.dphi) / ring.dphi;
@@ -350,10 +350,10 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 	}
 
 	if (ir1 == 0) {
-		double wtheta = theta / theta2;
-		weights[2] *= wtheta;
-		weights[3] *= wtheta;
-		double fac = (1 - wtheta) * 0.25;
+		double wz = z / z2;
+		weights[2] *= wz;
+		weights[3] *= wz;
+		double fac = (1 - wz) * 0.25;
 		weights[0] = fac;
 		weights[1] = fac;
 		weights[2] += fac;
@@ -361,10 +361,10 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 		pixels[0] = (pixels[2] + 2) & 3;
 		pixels[1] = (pixels[3] + 2) & 3;
 	} else if (ir2 == nring_) {
-		double wtheta = (theta - theta1) / (M_PI - theta1);
-		weights[0] *= 1 - wtheta;
-		weights[1] *= 1 - wtheta;
-		double fac = wtheta * 0.25;
+		double wz = (z - z1) / (M_PI - z1);
+		weights[0] *= 1 - wz;
+		weights[1] *= 1 - wz;
+		double fac = wz * 0.25;
 		weights[0] += fac;
 		weights[1] += fac;
 		weights[2] = fac;
@@ -372,11 +372,11 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 		pixels[2] = ((pixels[0] + 2) & 3) + npix_ - 4;
 		pixels[3] = ((pixels[1] + 2) & 3) + npix_ - 4;
 	} else {
-		double wtheta = (theta - theta1) / (theta2 - theta1);
-		weights[0] *= 1 - wtheta;
-		weights[1] *= 1 - wtheta;
-		weights[2] *= wtheta;
-		weights[3] *= wtheta;
+		double wz = (z - z1) / (z2 - z1);
+		weights[0] *= 1 - wz;
+		weights[1] *= 1 - wz;
+		weights[2] *= wz;
+		weights[3] *= wz;
 	}
 
 	if (nested_) {

--- a/maps/tests/healpix_maps.py
+++ b/maps/tests/healpix_maps.py
@@ -76,7 +76,7 @@ assert(np.allclose(pixels, pixels2))
 dx = x.res / 2.0
 vx = np.asarray(x.get_interp_values(alpha + dx, delta + dx))
 vh = hp.get_interp_val(np.asarray(x), theta - dx, phi + dx)
-assert(np.allclose(vx, vh))
+assert(not np.allclose(vx, vh))
 
 # Query disc
 avec = []


### PR DESCRIPTION
The weights computed for bilinear interpolation are computed in (theta, phi) coordinates, such that the effective sample location is shifted north or south compared to its actual location, with a shift amplitude that scales like 1/nside and is largest near the poles.  This PR changes the GetInterpPixelsWeights method to compute weights in (z, phi) coordinates, so that the weights are area-preserving and calculated in the coordinates in which the Healpix pixel boundaries are defined.

Note that this means that `HealpixSkyMap.get_interp_values()` no longer produces the same results as `healpy.get_interp_val()`.

Thank you to Eric Hivon for identifying the issue.