### PR TITLE
Add missing #include

### DIFF
--- a/core/include/core/G3NetworkSender.h
+++ b/core/include/core/G3NetworkSender.h
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <condition_variable>
 
+#include <core/G3Module.h>
+
 class G3NetworkSender : public G3Module {
 public:
 	G3NetworkSender(std::string hostname, int port, int max_queue_size);


### PR DESCRIPTION
Include the base class declaration so that this header file is actually usable.