### PR TITLE
add pyproject.toml, handle no bzip2, cmake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/env-shell.sh.in ${CMAKE_BINARY_DIR}/env
 execute_process(COMMAND mkdir -p ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 execute_process(COMMAND mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 execute_process(COMMAND ln -fsn ${CMAKE_SOURCE_DIR}/cmake/init.py ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/__init__.py)
+execute_process(COMMAND ln -fsn ${CMAKE_SOURCE_DIR}/pyproject.toml ${CMAKE_BINARY_DIR}/pyproject.toml)
 
 set(BUILD_PROJECTS "${BUILD_PROJECTS}" CACHE STRING "The subset of available projects to actually build")
 if(NOT "${BUILD_PROJECTS}" STREQUAL "")
@@ -164,7 +165,7 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/CTestCustom.cmake.in ${CMAKE_BINARY_DIR
 # Target for version string
 add_custom_target(version ALL
 	COMMAND sh ${CMAKE_SOURCE_DIR}/cmake/getvers.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/spt3g/version.py
-	COMMAND cmake -P ${CMAKE_SOURCE_DIR}/cmake/Spt3gVersion.cmake ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/Spt3gVersion.cmake ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
 	BYPRODUCTS ${CMAKE_BINARY_DIR}/spt3g/version.py ${CMAKE_BINARY_DIR}/cmake/Spt3gConfigVersion.cmake
 	COMMENT "Regenerating VCS version information"
 )

--- a/cmake/Spt3gBoostPython.cmake
+++ b/cmake/Spt3gBoostPython.cmake
@@ -45,7 +45,9 @@ else()
 endif()
 
 # suppress configuration warnings in newer cmake / boost versions
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+if (NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+	set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
 
 if(NOT DEFINED Boost_PYTHON_TYPE)
 	set(Boost_PYTHON_TYPE python)
@@ -65,4 +67,4 @@ if(NOT DEFINED Boost_PYTHON_TYPE)
 	endif()
 endif()
 
-find_package(Boost COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system iostreams filesystem ${Boost_PYTHON_TYPE} OPTIONAL_COMPONENTS bzip2)

--- a/cmake/getvers.sh
+++ b/cmake/getvers.sh
@@ -126,7 +126,7 @@ else
 	echo revision=\"UNKNOWN VCS\"
 	echo gitrevision=\"UNKNOWN\"
 	echo versionname=\"UNKNOWN\"
-	if [ "$(cat VERSION)" == "\$Version\$" ]; then
+	if [ "$(cat VERSION)" = '$Version$' ]; then
 		echo localdiffs=True
 		echo fullversion=\"UNKNOWN\"
 	else

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -24,7 +24,11 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 	if (boost::algorithm::ends_with(path, ".gz"))
 		stream.push(boost::iostreams::gzip_decompressor());
 	if (boost::algorithm::ends_with(path, ".bz2"))
+#ifdef Boost_BZIP2_FOUND
 		stream.push(boost::iostreams::bzip2_decompressor());
+#else
+		log_fatal("Boost not compiled with bzip2 support.");
+#endif
 
 	int fd = -1;
 

--- a/dfmux/CMakeLists.txt
+++ b/dfmux/CMakeLists.txt
@@ -14,6 +14,9 @@ add_spt3g_library(dfmux SHARED
 	${DFMUX_LIB_EXTRA_SRC}
 )
 target_link_libraries(dfmux core ${DFMUX_LIB_EXTRA_LIB})
+if (NETCDF_FOUND)
+	target_include_directories(dfmux PRIVATE ${NETCDF_INCLUDES})
+endif()
 
 if (NETCDF_FOUND)
 	add_spt3g_program(bin/ledgerman.py ledgerman)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "spt3g"
+version = "0.1.0"
+description = ""
+authors = ["SPT Collaboration"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+numpy = "^1.15"
+astropy = "^5"
+scipy = "^1.4.1"
+pandas = "^1"
+healpy = "^1.13"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
A number of small generic cmake fixes, and a few things specifically to make https://github.com/marius311/Spt3G.jl possible. 

1. Makes it possible for the user to override `CMAKE_FIND_PACKAGE_PREFER_CONFIG` to instead favor MODULE-mode find_package. No change to the current default (CONFIG-mode) if nothing is specified. 
  
   The problem with CONFIG-mode is it seems to sometimes do too good of a job finding `*config.cmake` files including ones you _dont_ want to use, with no way (that I found) to turn that off. Specifically it was finding `$HOME/lib/cmake/Boost.config.cmake` via option 4 [here](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure) (via some built in `HINTS` or something that have no option to be turned off)

1. It turns out Boost can be built without bzip2 support. Cmake can discover this. This makes spt3g_software still build-able in that case.
 
1. A NETCDF include file seemed to not be properly specified before (it probably worked fine before if the file was on a system-wide include folder)

1. Add `pyproject.toml` to record Python dependencies and make the repo [PEP 518](https://peps.python.org/pep-0518/) compliant. Means you can add a built spt3g_software to some virtual environment with e.g. `poetry add -e /path/to/spt3g_software/build` and all Python dependencies get installed (haven't played with this outside of `poetry` but I think in theory `pip` and some others can do the same). Would be great if this file could be used to keep dependency compatibility bounds up-to-date, as this is not really recorded anywhere afaict. 


Happy to take any comments on this. I tried to touch as little as possible while making the Spt3G.jl thing work. 
