### PR TITLE
G3NetworkSender background serialization

### DIFF
--- a/core/include/core/G3NetworkSender.h
+++ b/core/include/core/G3NetworkSender.h
@@ -6,38 +6,111 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <future>
 
 #include <core/G3Module.h>
 
 class G3NetworkSender : public G3Module {
 public:
-	G3NetworkSender(std::string hostname, int port, int max_queue_size);
+	G3NetworkSender(std::string hostname, int port, int max_queue_size,
+	                int n_serializers=0);
 	virtual ~G3NetworkSender();
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
 	void Close(void);
+	uint64_t FramesDroppedFromSerialization() const{ return n_serial_drops_; }
+	uint64_t FramesDroppedFromSending() const{ return n_send_drops_; }
 private:
 	int fd_;
 	int max_queue_size_;
 	bool listening_;
+	int n_serializers_;
+	uint64_t n_serial_drops_;
+	uint64_t n_send_drops_;
 
-	typedef boost::shared_ptr<std::vector<char> > netbuf_type;
+	using netbuf_type = boost::shared_ptr<std::vector<char>>;
+	using buffer_future = std::shared_future<netbuf_type>;
 
-	struct thread_data {
-		std::thread thread;
-		std::mutex queue_lock;
-		std::condition_variable queue_sem;
-		std::deque<netbuf_type> queue;
+	template<typename InputType>
+	struct input_queue {
+		input_queue():die(false) {}
 
-		int fd;
+		int max_size;
+		std::mutex lock;
+		std::condition_variable sem;
+		std::deque<InputType> queue;
+
 		bool die; // Protected by queue lock
+
+		bool insert(InputType&& item, bool low_priority=false) {
+			std::lock_guard<std::mutex> lg(lock);
+			// Refuse to put anything into stopped queues, and if a maximum
+			// queue size is set and would be exceeded, drop low priority data
+			if (die || (max_size && low_priority && queue.size()>=max_size))
+				return false;
+			queue.push_back(std::move(item));
+			// If the queue is shared, only one worker needs to wake up, and if
+			// it is private, there is only one in the first place.
+			sem.notify_one();
+			return true;
+		}
+
+		void stop() {
+			std::lock_guard<std::mutex> lg(lock);
+			die = true;
+			// If the queue is shared, all workers need to wake up.
+			sem.notify_all();
+		}
+
+		bool empty() const { return queue.empty(); }
+
+		typename std::deque<InputType>::reference front() {
+			return queue.front();
+		}
+
+		typename std::deque<InputType>::const_reference front() const {
+			return queue.front();
+		}
+
+		void pop_front(){ queue.pop_front(); }
 	};
 
-	std::vector<boost::shared_ptr<thread_data> > threads_;
-	static void SendLoop(boost::shared_ptr<struct thread_data>);
-	void StartThread(int fd);
-	void ReapDeadThreads(void);
+	struct serialization_task {
+		G3FramePtr input;
+		std::promise<netbuf_type> output;
+	};
 
-	std::vector<std::pair<G3Frame::FrameType, netbuf_type> > metadata_;
+	struct serializer_thread_data{
+		serializer_thread_data(input_queue<serialization_task>& q):queue(q) {}
+
+		std::thread thread;
+		//shares a queue with other instances
+		input_queue<serialization_task>& queue;
+	};
+
+	struct network_thread_data{
+		std::thread thread;
+		//has its own queue
+		input_queue<buffer_future> queue;
+		int fd;
+	};
+
+	struct output_rcord {
+		G3FramePtr frame;
+		buffer_future output;
+	};
+
+	input_queue<serialization_task> serialization_queue;
+	std::vector<boost::shared_ptr<serializer_thread_data>> serializer_threads_;
+	std::vector<boost::shared_ptr<network_thread_data>> network_threads_;
+	std::deque<output_rcord> outstanding_frames;
+	static void SerializeFrame(serialization_task& task);
+	static void SerializeLoop(boost::shared_ptr<serializer_thread_data>);
+	static void SendLoop(boost::shared_ptr<network_thread_data>);
+	void StartThread(int fd);
+	void StopAllThreads();
+	void ReapDeadThreads();
+
+	std::vector<std::pair<G3Frame::FrameType, buffer_future>> metadata_;
 
 	SET_LOGGER("G3NetworkSender");
 };

--- a/core/include/core/SetThreadName.h
+++ b/core/include/core/SetThreadName.h
@@ -1,0 +1,27 @@
+#ifndef SETTHREADNAME_H
+#define SETTHREADNAME_H
+
+#include <string>
+
+#include <pthread.h>
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
+
+/// Set the name for the currently-running thread
+/// \param name the thread name to set, which should not exceed 15 characters
+inline void setThreadName(std::string name){
+	if(name.size()>15) // Linux limits thread names to 15 bytes
+		name=name.substr(0,15);
+#if defined(__linux__) || defined(__FreeBSD__) \
+		|| defined(__NetBSD__) || defined(__OpenBSD__)
+	pthread_setname_np(pthread_self(), name.c_str());
+#endif
+#ifdef __APPLE__
+	// Apple refuses to allow setting the name on anything but the current
+	// thread, for some reason
+	pthread_setname_np(name.c_str());
+#endif
+}
+
+#endif //SETTHREADNAME_H

--- a/core/src/G3EventBuilder.cxx
+++ b/core/src/G3EventBuilder.cxx
@@ -1,22 +1,12 @@
 #include <G3EventBuilder.h>
 #include <G3Pipeline.h>
 #include <pybindings.h>
-
-#ifdef __FreeBSD__
-#include <pthread_np.h>
-#endif
+#include <core/SetThreadName.h>
 
 G3EventBuilder::G3EventBuilder(int warn_size) :
   G3Module(), warn_size_(warn_size), dead_(false)
 {
 	process_thread_ = std::thread(ProcessThread, this);
-
-#ifdef __linux__
-	pthread_setname_np(process_thread_.native_handle(), "event builder");
-#endif
-#ifdef __FreeBSD__
-	pthread_set_name_np(process_thread_.native_handle(), "event builder");
-#endif
 }
 
 G3EventBuilder::~G3EventBuilder()
@@ -102,6 +92,7 @@ void G3EventBuilder::CollectPolledData(G3FramePtr frame)
 
 void G3EventBuilder::ProcessThread(G3EventBuilder *builder)
 {
+	setThreadName("event builder");
 	std::unique_lock<std::mutex> lock(builder->queue_lock_);
 
 	while (1) {

--- a/core/src/G3PipelineInfo.cxx
+++ b/core/src/G3PipelineInfo.cxx
@@ -17,6 +17,12 @@ template <class A> void G3ModuleConfig::save(A &ar, unsigned v) const
 
 	ar << cereal::make_nvp("size", config.size());
 
+	struct gil_holder{
+		PyGILState_STATE gs;
+		gil_holder():gs(PyGILState_Ensure()){}
+		~gil_holder(){ PyGILState_Release(gs); }
+	} gh;
+
 	for (auto i : config) {
 		ar << cereal::make_nvp("key", i.first);
 		

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -14,7 +14,6 @@
 
 #ifdef __FreeBSD__
 #include <sys/endian.h>
-#include <pthread_np.h>
 #endif
 
 #ifdef __APPLE__
@@ -38,6 +37,7 @@
 
 #include <dfmux/DfMuxCollector.h>
 
+#include <core/SetThreadName.h>
 
 struct RawTimestamp {
 	/* SIGNED types are used here to permit negative numbers during
@@ -236,13 +236,6 @@ int DfMuxCollector::Start()
 	stop_listening_ = false;
 	listen_thread_ = std::thread(Listen, this);
 
-#ifdef __linux__
-	pthread_setname_np(listen_thread_.native_handle(), "dfmux listen");
-#endif
-#ifdef __FreeBSD__
-	pthread_set_name_np(listen_thread_.native_handle(), "dfmux listen");
-#endif
-
 	return (0);
 }
 
@@ -256,6 +249,8 @@ int DfMuxCollector::Stop()
 
 void DfMuxCollector::Listen(DfMuxCollector *collector)
 {
+	setThreadName("dfmux listen");
+
 	struct sockaddr_in addr;
 	socklen_t addrlen = sizeof(addr);
 	struct DfmuxPacket buf;


### PR DESCRIPTION
Refactor G3NetworkSender so that it can handle larger rates of large frames, for which frame serialization overhead can dominate over transmission time. To do this, the option is provided to run some number of background threads responsible for serializing frames. The default is to use zero serializer threads, and to continue to serialize on the main thread, as has previously been the case. Because the access to the serialized blobs inside G3Frame is not currently thread safe, frames are not emitted from G3NetworkSender until their serialization is completed. The mechanism to coordinate this also adds some small overhead to the case of serializing on the main thread, which appears to be unimportant, but which could be avoided if there is a need to do so. 