### PR TITLE
xy_to_pixel and pixel_to_xy methods for flat sky maps

### DIFF
--- a/maps/include/maps/FlatSkyMap.h
+++ b/maps/include/maps/FlatSkyMap.h
@@ -118,6 +118,8 @@ public:
 	std::vector<double> PixelToAngleWrapRa(size_t pixel) const;
 	std::vector<double> AngleToXY(double alpha, double delta) const;
 	std::vector<double> XYToAngle(double x, double y) const;
+	size_t XYToPixel(double x, double y) const;
+	std::vector<double> PixelToXY(size_t pixel) const;
 	std::vector<double> QuatToXY(quat q) const;
 	quat XYToQuat(double x, double y) const;
 


### PR DESCRIPTION
This should be equivalent to `numpy.unravel_index`.