### PR TITLE
Explicitly force G3TimestreamMap to have assignment operators

### DIFF
--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -180,6 +180,9 @@ public:
 	G3TimestreamMap(const G3TimestreamMap& other):std::map<std::string, G3TimestreamPtr>(other){}
 	G3TimestreamMap(G3TimestreamMap&& other):std::map<std::string, G3TimestreamPtr>(std::move(other)){}
 
+	G3TimestreamMap& operator=(const G3TimestreamMap&)=default;
+	G3TimestreamMap& operator=(G3TimestreamMap&&)=default;
+
 	// Return true if all timestreams start and end at the same time and
 	// contain the same number of samples.
 	bool CheckAlignment() const;

--- a/core/tests/G3TimestreamMapTest.cxx
+++ b/core/tests/G3TimestreamMapTest.cxx
@@ -1,10 +1,28 @@
 #include <G3Test.h>
 
+#include <type_traits>
+
 #include <core/G3Timestream.h>
 
 #include <boost/make_shared.hpp>
 
 TEST_GROUP(G3TimestreamMap)
+
+//These things can be checked purely at compile time
+static_assert(std::is_default_constructible<G3TimestreamMap>::value,
+              "G3TimestreamMap must be default constructible");
+
+static_assert(std::is_copy_constructible<G3TimestreamMap>::value,
+              "G3TimestreamMap must be copy constructible");
+
+static_assert(std::is_move_constructible<G3TimestreamMap>::value,
+              "G3TimestreamMap must be move constructible");
+
+static_assert(std::is_copy_assignable<G3TimestreamMap>::value,
+              "G3TimestreamMap must be copy assignable");
+
+static_assert(std::is_move_assignable<G3TimestreamMap>::value,
+              "G3TimestreamMap must be move assignable");
 
 template<typename SampleType>
 void testMakeCompact(){


### PR DESCRIPTION
This solves the issue in https://github.com/CMB-S4/spt3g_software/issues/101.