### PR TITLE
Timestream serialization speed

### DIFF
--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -137,11 +137,13 @@ template <class A> void G3Timestream::save(A &ar, unsigned v) const
 		// rare case that only some samples are valid, store a
 		// validity mask.
 		std::vector<bool> nanbuf(size(), false);
-		for (size_t i = 0; i < size(); i++) {
-			if (!std::isfinite((*this)[i])) {
-				nans++;
-				nanbuf[i] = true;
-				inbuf[i] = 0;
+		if(data_type_==TS_DOUBLE || data_type_==TS_FLOAT){
+			for (size_t i = 0; i < size(); i++) {
+				if (!std::isfinite((*this)[i])) {
+					nans++;
+					nanbuf[i] = true;
+					inbuf[i] = 0;
+				}
 			}
 		}
 		nanflag = SomeNan;


### PR DESCRIPTION
These changes roughly double the speed at which large amounts of integer timestream data can be serialized, and should provide much of that benefit to more common floating-point data, as well. 