### PR TITLE
Updates to dfmux library for compatibility with hidfmux IceBoard firmware

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,8 +86,8 @@ jobs:
         cp -r ${{runner.workspace}}/build/docs/* gh-pages/
         cd gh-pages
         touch .nojekyll
-        git config --local user.name github-actions
-        git config --local user.email github-actions@github.com
+        git config --local user.name github-actions[bot]
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add .
         git commit -m "Update documentation" -a || true
         git push

--- a/calibration/include/calibration/BoloProperties.h
+++ b/calibration/include/calibration/BoloProperties.h
@@ -13,7 +13,8 @@ class BolometerProperties : public G3FrameObject
 {
 public:
 	BolometerProperties() : x_offset(NAN), y_offset(NAN), band(NAN),
-	    pol_angle(NAN), pol_efficiency(NAN), coupling(Unknown) {}
+	    center_frequency(NAN), bandwidth(NAN), pol_angle(NAN),
+	    pol_efficiency(NAN), coupling(Unknown) {}
 	std::string Description() const;
 
 	std::string physical_name; /* e.g. D4.A2.3.Y */
@@ -24,6 +25,7 @@ public:
 
 	double band;		/* Standard frequency units */
 	double center_frequency;
+	double bandwidth;
 	double pol_angle;	/* Standard angular units */
 	double pol_efficiency;	/* 0-1 */
 

--- a/calibration/include/calibration/BoloProperties.h
+++ b/calibration/include/calibration/BoloProperties.h
@@ -23,6 +23,7 @@ public:
 	double y_offset; /* and el */
 
 	double band;		/* Standard frequency units */
+	double center_frequency;
 	double pol_angle;	/* Standard angular units */
 	double pol_efficiency;	/* 0-1 */
 
@@ -44,7 +45,7 @@ public:
 };
 
 G3_POINTERS(BolometerProperties);
-G3_SERIALIZABLE(BolometerProperties, 6);
+G3_SERIALIZABLE(BolometerProperties, 7);
 
 G3MAP_OF(std::string, BolometerProperties, BolometerPropertiesMap);
 

--- a/calibration/src/BoloProperties.cxx
+++ b/calibration/src/BoloProperties.cxx
@@ -40,6 +40,9 @@ template <class A> void BolometerProperties::serialize(A &ar, unsigned v)
 		ar & make_nvp("pixel_type", pixel_type);
 	}
 
+	if (v > 6) {
+		ar & make_nvp("center_frequency", center_frequency);
+	}
 }
 
 std::string BolometerProperties::Description() const
@@ -63,7 +66,9 @@ PYBINDINGS("calibration") {
 	    .def_readwrite("y_offset", &BolometerProperties::y_offset,
 	       "Vertical pointing offset relative to boresight in angular units.")
 	    .def_readwrite("band", &BolometerProperties::band,
-	       "Center of detector observing band in frequency units")
+	       "Nominal center of detector observing band in frequency units")
+	    .def_readwrite("center_frequency", &BolometerProperties::center_frequency,
+	       "Measured center of detector observing band in frequency units")
 	    .def_readwrite("pol_angle", &BolometerProperties::pol_angle,
 	       "Polarization angle in angular units")
 	    .def_readwrite("pol_efficiency", &BolometerProperties::pol_efficiency,

--- a/calibration/src/BoloProperties.cxx
+++ b/calibration/src/BoloProperties.cxx
@@ -42,6 +42,7 @@ template <class A> void BolometerProperties::serialize(A &ar, unsigned v)
 
 	if (v > 6) {
 		ar & make_nvp("center_frequency", center_frequency);
+		ar & make_nvp("bandwidth", bandwidth);
 	}
 }
 
@@ -69,6 +70,8 @@ PYBINDINGS("calibration") {
 	       "Nominal center of detector observing band in frequency units")
 	    .def_readwrite("center_frequency", &BolometerProperties::center_frequency,
 	       "Measured center of detector observing band in frequency units")
+	    .def_readwrite("bandwidth", &BolometerProperties::bandwidth,
+	       "Measured bandwidth of detector observing band in frequency units")
 	    .def_readwrite("pol_angle", &BolometerProperties::pol_angle,
 	       "Polarization angle in angular units")
 	    .def_readwrite("pol_efficiency", &BolometerProperties::pol_efficiency,
@@ -77,7 +80,7 @@ PYBINDINGS("calibration") {
 	       "Optical coupling type")
 
 	    .def_readwrite("wafer_id", &BolometerProperties::wafer_id,
-	       "Name of the name this detector is on")
+	       "Name of the wafer this detector is on")
 	    .def_readwrite("pixel_id", &BolometerProperties::pixel_id,
 	       "Name of the pixel of which this detector is a part")
 	    .def_readwrite("pixel_type", &BolometerProperties::pixel_type,

--- a/dfmux/include/dfmux/DfMuxBuilder.h
+++ b/dfmux/include/dfmux/DfMuxBuilder.h
@@ -16,6 +16,7 @@
 struct DfMuxBoardSamples : public G3FrameObject, public std::map<int32_t, DfMuxSamplePtr> {
 	size_t nmodules; // Total number of modules expected from this board
 	size_t nblocks; // Total number of sub-module blocks expected from this board
+	size_t nchannels; // Total number of channels per block expected from this board
 	
 	bool Complete() const { return (size() == nmodules * nblocks); };
 	template <class A> void serialize(A &ar, unsigned v);

--- a/dfmux/include/dfmux/DfMuxBuilder.h
+++ b/dfmux/include/dfmux/DfMuxBuilder.h
@@ -15,13 +15,14 @@
  */
 struct DfMuxBoardSamples : public G3FrameObject, public std::map<int32_t, DfMuxSamplePtr> {
 	size_t nmodules; // Total number of modules expected from this board
+	size_t nblocks; // Total number of sub-module blocks expected from this board
 	
-	bool Complete() const { return (size() == nmodules); };
+	bool Complete() const { return (size() == nmodules * nblocks); };
 	template <class A> void serialize(A &ar, unsigned v);
 };
 
 G3_POINTERS(DfMuxBoardSamples);
-G3_SERIALIZABLE(DfMuxBoardSamples, 1);
+G3_SERIALIZABLE(DfMuxBoardSamples, 2);
 
 /*
  * DfMuxMetaSample: collection of DfMuxBoardSamples, indexed by board serial

--- a/dfmux/include/dfmux/DfMuxCollector.h
+++ b/dfmux/include/dfmux/DfMuxCollector.h
@@ -19,6 +19,7 @@ public:
 	int32_t block;          /* Sub-module block number (0-7) */
 	int32_t nmodules;	/* Total number of modules on board (8) */
 	int32_t nblocks;        /* Total number of blocks per module (8) */
+	int32_t nchannels;      /* Total number of channels per block (128) */
 	DfMuxSamplePtr sample;	/* Pointer to the DfMuxSample */
 };
 

--- a/dfmux/include/dfmux/DfMuxCollector.h
+++ b/dfmux/include/dfmux/DfMuxCollector.h
@@ -50,6 +50,10 @@ public:
 	int Start();	// Start listening thread
 	int Stop();	// Stop listening thread
 
+	// Configure iceboard clock rate
+	void SetClockRate(uint64_t rate) { clock_rate_ = rate; };
+	uint64_t GetClockRate() { return clock_rate_; };
+
 private:
 	int SetupUDPSocket(const char *listenaddr);
 	int SetupSCTPSocket(std::vector<std::string> hosts);
@@ -67,6 +71,7 @@ private:
 	std::vector<int32_t> board_list_;
 	int fd_;
 	in_addr_t listenaddr_;
+	uint64_t clock_rate_;
 
 	SET_LOGGER("DfMuxCollector");
 };

--- a/dfmux/include/dfmux/DfMuxCollector.h
+++ b/dfmux/include/dfmux/DfMuxCollector.h
@@ -53,8 +53,8 @@ public:
 	int Stop();	// Stop listening thread
 
 	// Configure iceboard clock rate
-	void SetClockRate(uint64_t rate) { clock_rate_ = rate; };
-	uint64_t GetClockRate() { return clock_rate_; };
+	void SetClockRate(double rate);
+	double GetClockRate() { return clock_rate_; };
 
 private:
 	int SetupUDPSocket(const char *listenaddr);
@@ -73,7 +73,8 @@ private:
 	std::vector<int32_t> board_list_;
 	int fd_;
 	in_addr_t listenaddr_;
-	uint64_t clock_rate_;
+	double clock_rate_;
+	double clock_scale_;
 
 	SET_LOGGER("DfMuxCollector");
 };

--- a/dfmux/include/dfmux/DfMuxCollector.h
+++ b/dfmux/include/dfmux/DfMuxCollector.h
@@ -16,7 +16,9 @@ class DfMuxSamplePacket : public G3FrameObject {
 public:
 	int32_t board;		/* Board serial number */
 	int32_t module;		/* Module number (0-7) */
+	int32_t block;          /* Sub-module block number (0-7) */
 	int32_t nmodules;	/* Total number of modules on board (8) */
+	int32_t nblocks;        /* Total number of blocks per module (8) */
 	DfMuxSamplePtr sample;	/* Pointer to the DfMuxSample */
 };
 

--- a/dfmux/include/dfmux/DfMuxCollector.h
+++ b/dfmux/include/dfmux/DfMuxCollector.h
@@ -16,9 +16,9 @@ class DfMuxSamplePacket : public G3FrameObject {
 public:
 	int32_t board;		/* Board serial number */
 	int32_t module;		/* Module number (0-7) */
-	int32_t block;          /* Sub-module block number (0-7) */
-	int32_t nmodules;	/* Total number of modules on board (8) */
-	int32_t nblocks;        /* Total number of blocks per module (8) */
+	int32_t block;          /* Sub-module block number (0-7 for hidfmux, 0 for dfmux) */
+	int32_t nmodules;	/* Total number of modules on board (8 for dfmux) */
+	int32_t nblocks;        /* Total number of blocks per module (8 for hidfmux, 1 for dfmux) */
 	int32_t nchannels;      /* Total number of channels per block (128) */
 	DfMuxSamplePtr sample;	/* Pointer to the DfMuxSample */
 };
@@ -53,7 +53,7 @@ public:
 	int Start();	// Start listening thread
 	int Stop();	// Stop listening thread
 
-	// Configure iceboard clock rate
+	// Configure iceboard clock rate (defaults to 100 MHz)
 	void SetClockRate(double rate);
 	double GetClockRate() { return clock_rate_; };
 

--- a/dfmux/src/DfMuxBuilder.cxx
+++ b/dfmux/src/DfMuxBuilder.cxx
@@ -19,6 +19,11 @@ template <class A> void DfMuxBoardSamples::serialize(A &ar, const unsigned v)
 	ar & make_nvp("G3FrameObject", base_class<G3FrameObject>(this));
 	ar & make_nvp("samples", base_class<std::map<int, DfMuxSamplePtr> >(this));
 	ar & make_nvp("nmodules", nmodules);
+
+	if (v > 1)
+		ar & make_nvp("nblocks", nblocks);
+	else
+		nblocks = 1;
 }
 
 G3_SERIALIZABLE_CODE(DfMuxBoardSamples);
@@ -124,10 +129,12 @@ void DfMuxBuilder::ProcessNewData()
 	}
 
 	// Add to meta sample
-	g3_assert((*sample->sample)[pkt->board].find(pkt->module) ==
+	int idx = pkt->module * pkt->nblocks + pkt->block;
+	g3_assert((*sample->sample)[pkt->board].find(idx) ==
 	    (*sample->sample)[pkt->board].end());
-	(*sample->sample)[pkt->board][pkt->module] = pkt->sample;
+	(*sample->sample)[pkt->board][idx] = pkt->sample;
 	(*sample->sample)[pkt->board].nmodules = pkt->nmodules;
+	(*sample->sample)[pkt->board].nblocks = pkt->nblocks;
 	
 	while (oqueue_.size() > 0 && oqueue_.front().sample->size() ==
 	    nboards_) {
@@ -203,12 +210,14 @@ PYBINDINGS("dfmux")
 	class_<DfMuxBoardSamples, bases<G3FrameObject>,
 	  DfMuxBoardSamplesPtr>("DfMuxBoardSamples",
 	  "Container structure for samples from modules on one board, mapping "
-	  "0-indexed module IDs to a dfmux.DfMuxSample.")
+	  "0-indexed module and block IDs to a dfmux.DfMuxSample.")
 	    .def(std_map_indexing_suite<DfMuxBoardSamples, true>())
 	    .def_readwrite("nmodules", &DfMuxBoardSamples::nmodules,
 	      "Number of modules expected to report from this board")
+	    .def_readwrite("nblocks", &DfMuxBoardSamples::nblocks,
+	      "Number of sub-module blocks expected to report from this board")
 	    .def("Complete", &DfMuxBoardSamples::Complete,
-	      "True if this structure contains data from all expected modules")
+	      "True if this structure contains data from all expected modules and blocks")
 	    .def_pickle(g3frameobject_picklesuite<DfMuxBoardSamples>())
 	;
 	register_pointer_conversions<DfMuxBoardSamples>();

--- a/dfmux/src/DfMuxBuilder.cxx
+++ b/dfmux/src/DfMuxBuilder.cxx
@@ -20,10 +20,13 @@ template <class A> void DfMuxBoardSamples::serialize(A &ar, const unsigned v)
 	ar & make_nvp("samples", base_class<std::map<int, DfMuxSamplePtr> >(this));
 	ar & make_nvp("nmodules", nmodules);
 
-	if (v > 1)
+	if (v > 1) {
 		ar & make_nvp("nblocks", nblocks);
-	else
+		ar & make_nvp("nchannels", nchannels);
+	} else {
 		nblocks = 1;
+		nchannels = 128;
+	}
 }
 
 G3_SERIALIZABLE_CODE(DfMuxBoardSamples);
@@ -135,6 +138,7 @@ void DfMuxBuilder::ProcessNewData()
 	(*sample->sample)[pkt->board][idx] = pkt->sample;
 	(*sample->sample)[pkt->board].nmodules = pkt->nmodules;
 	(*sample->sample)[pkt->board].nblocks = pkt->nblocks;
+	(*sample->sample)[pkt->board].nchannels = pkt->nchannels;
 	
 	while (oqueue_.size() > 0 && oqueue_.front().sample->size() ==
 	    nboards_) {
@@ -216,6 +220,8 @@ PYBINDINGS("dfmux")
 	      "Number of modules expected to report from this board")
 	    .def_readwrite("nblocks", &DfMuxBoardSamples::nblocks,
 	      "Number of sub-module blocks expected to report from this board")
+	    .def_readwrite("nchannels", &DfMuxBoardSamples::nchannels,
+	      "Number of channels per block expected to report from this board")
 	    .def("Complete", &DfMuxBoardSamples::Complete,
 	      "True if this structure contains data from all expected modules and blocks")
 	    .def_pickle(g3frameobject_picklesuite<DfMuxBoardSamples>())

--- a/dfmux/src/DfMuxCollator.cxx
+++ b/dfmux/src/DfMuxCollator.cxx
@@ -141,24 +141,35 @@ void DfMuxCollator::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 			if (board == metasamp->end())
 				continue;
 
-			auto module = board->second.find(chan->mapping->module);
+			int mod_idx, chan_idx;
+			// slight hackery for indexing timepoint frames with modules split into blocks (e.g. with hidfmux)
+			// hard-coded number of channels per block
+			if (board->second.nblocks != 1) {
+				mod_idx = chan->mapping->module * board->second.nblocks + (int)(chan->mapping->channel / board->second.nchannels);
+				chan_idx = chan->mapping->channel % board->second.nchannels;
+			} else {
+				mod_idx = chan->mapping->module;
+				chan_idx = chan->mapping->channel;
+			}
+
+			auto module = board->second.find(mod_idx);
 			if (module == board->second.end())
 				continue;
 
 			if (module->second->size()/2 <
-			    size_t(chan->mapping->channel)) {
-				log_fatal("Board %d, module %d only has %zd "
+			    size_t(chan_idx)) {
+				log_fatal("Board %d, module block %d only has %zd "
 				    "channels, but trying to read %d",
 				    chan->mapping->board_serial,
-				    chan->mapping->module,
+				    mod_idx,
 				    module->second->size()/2,
-				    chan->mapping->channel);
+				    chan_idx);
 			}
 
 			(*chan->i)[sample] =
-			    (*module->second)[chan->mapping->channel*2];
+			    (*module->second)[chan_idx*2];
 			(*chan->q)[sample] =
-			    (*module->second)[chan->mapping->channel*2 + 1];
+			    (*module->second)[chan_idx*2 + 1];
 		}
 
 		// Next run through aux data. Missing points get filled in

--- a/dfmux/src/DfMuxCollator.cxx
+++ b/dfmux/src/DfMuxCollator.cxx
@@ -143,7 +143,6 @@ void DfMuxCollator::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 
 			int mod_idx, chan_idx;
 			// slight hackery for indexing timepoint frames with modules split into blocks (e.g. with hidfmux)
-			// hard-coded number of channels per block
 			if (board->second.nblocks != 1) {
 				mod_idx = chan->mapping->module * board->second.nblocks + (int)(chan->mapping->channel / board->second.nchannels);
 				chan_idx = chan->mapping->channel % board->second.nchannels;

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -447,7 +447,7 @@ PYBINDINGS("dfmux")
 	    .def("Start", &DfMuxCollector::Start)
 	    .def("Stop", &DfMuxCollector::Stop)
 	    .add_property("clock_rate", &DfMuxCollector::GetClockRate, &DfMuxCollector::SetClockRate,
-	      "Set the clock rate for the iceboard subseconds counter, e.g. for hidfmux.  Values should be in G3Units of frequency (e.g. 100*core.G3Units.MHz)")
+	      "Set the clock rate for the iceboard subseconds counter, e.g. for hidfmux.  Values should be in G3Units of frequency.  Defaults to 100*core.G3Units.MHz.")
 	;
 }
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -62,7 +62,7 @@ struct DfmuxPacket {
 
 	uint32_t seq; /* incrementing sequence number */
 
-	int32_t s[256]; /* >= largest number of channels we expect */
+	int32_t s[1024]; /* >= largest number of channels we expect */
 	struct RawTimestamp ts;
 } __attribute__((packed));
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -386,6 +386,7 @@ int DfMuxCollector::BookPacket(struct DfmuxPacket *packet, struct in_addr src)
 	// (firmware V3 and below)
 	outpacket->nmodules = (le16toh(packet->version) == 4) ? le32toh(packet->num_modules) : 8;
 	outpacket->nblocks = (le16toh(packet->version) == 4) ? 8 : 1;
+	outpacket->nchannels = nchan;
 
 	builder_->AsyncDatum(timecode, outpacket);
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -447,7 +447,7 @@ PYBINDINGS("dfmux")
 	    .def("Start", &DfMuxCollector::Start)
 	    .def("Stop", &DfMuxCollector::Stop)
 	    .add_property("clock_rate", &DfMuxCollector::GetClockRate, &DfMuxCollector::SetClockRate,
-	      "Set the clock rate for the iceboard subseconds counter, e.g. for hidfmux.  Values should be in G3Units of frequency (e.g. 125*core.G3Units.MHz)")
+	      "Set the clock rate for the iceboard subseconds counter, e.g. for hidfmux.  Values should be in G3Units of frequency (e.g. 100*core.G3Units.MHz)")
 	;
 }
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -56,7 +56,7 @@ struct DfmuxPacket {
 	uint16_t serial; /* zero for V2, filled for V3 */
 
 	uint8_t num_modules;
-	uint8_t channels_per_module;
+	uint8_t channels_per_module; /* this means something else for v4 [hidfmux] firmware */
 	uint8_t fir_stage;
 	uint8_t module; /* linear; 0-7. don't like it much. */
 
@@ -361,7 +361,8 @@ int DfMuxCollector::BookPacket(struct DfmuxPacket *packet, struct in_addr src)
 
 	// Work around bug in IceBoard firmware. You always get 8 modules'
 	// worth of packets, no matter what packet->num_modules says.
-	outpacket->nmodules = 8;
+	// version 4 firmware expects only one module (hidfmux)
+	outpacket->nmodules = (le16toh(packet->version) == 4) ? 1 : 8;
 
 	builder_->AsyncDatum(timecode, outpacket);
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -160,8 +160,8 @@ DfMuxCollector::DfMuxCollector(const char *listenaddr,
 void DfMuxCollector::SetClockRate(double rate)
 {
 
-  clock_rate_ = rate;
-  clock_scale_ = 100 * G3Units::MHz / clock_rate_;
+	clock_rate_ = rate;
+	clock_scale_ = 100 * G3Units::MHz / clock_rate_;
 }
 
 int DfMuxCollector::SetupUDPSocket(const char *listenaddr)

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -359,13 +359,13 @@ int DfMuxCollector::BookPacket(struct DfmuxPacket *packet, struct in_addr src)
 
 	DfMuxSamplePacketPtr outpacket(new DfMuxSamplePacket);
 	outpacket->board = board_id;
-	outpacket->module = le32toh(packet->module);
+	outpacket->module = (le16toh(packet->version) == 4) ?
+	  le32toh(packet->channels_per_module) : le32toh(packet->module);
 	outpacket->sample = sample;
 
 	// Work around bug in IceBoard firmware. You always get 8 modules'
 	// worth of packets, no matter what packet->num_modules says.
-	// version 4 firmware expects only one module (hidfmux)
-	outpacket->nmodules = (le16toh(packet->version) == 4) ? 1 : 8;
+	outpacket->nmodules = 8;
 
 	builder_->AsyncDatum(timecode, outpacket);
 

--- a/dfmux/src/DfMuxCollector.cxx
+++ b/dfmux/src/DfMuxCollector.cxx
@@ -326,7 +326,8 @@ int DfMuxCollector::BookPacket(struct DfmuxPacket *packet, struct in_addr src)
 	}
 
 	modseq = &sequence_[board_id];
-	mod_id = (le16toh(packet->version) == 4) ? le32toh(packet->channels_per_module) :
+	mod_id = (le16toh(packet->version) == 4) ?
+	  (le32toh(packet->module) * 8 + le32toh(packet->channels_per_module)) :
 	  le32toh(packet->module);
 	seq = modseq->find(mod_id);
 	if (seq != modseq->end()) {

--- a/dfmux/src/LegacyDfMuxCollector.cxx
+++ b/dfmux/src/LegacyDfMuxCollector.cxx
@@ -294,6 +294,7 @@ int LegacyDfMuxCollector::BookPacket(struct DfmuxPacket *packet,
 		outpacket->block = 0;
 		outpacket->nmodules = 4;
 		outpacket->nblocks = 1;
+		outpacket->nchannels = 16;
 
 		builder_->AsyncDatum(timecode, outpacket);
 	}

--- a/dfmux/src/LegacyDfMuxCollector.cxx
+++ b/dfmux/src/LegacyDfMuxCollector.cxx
@@ -291,7 +291,9 @@ int LegacyDfMuxCollector::BookPacket(struct DfmuxPacket *packet,
 	
 		outpacket->sample = sample;
 		outpacket->module = m;
+		outpacket->block = 0;
 		outpacket->nmodules = 4;
+		outpacket->nblocks = 1;
 
 		builder_->AsyncDatum(timecode, outpacket);
 	}

--- a/gcp/src/GCPMuxDataDecoder.cxx
+++ b/gcp/src/GCPMuxDataDecoder.cxx
@@ -325,6 +325,7 @@ GCPMuxDataDecoder::Process(G3FramePtr frame, std::deque<G3FramePtr> &out_queue)
 		for (auto j = metasample->begin(); j != metasample->end(); j++) {
 			j->second.nmodules = j->second.size();
 			j->second.nblocks = 1;
+			j->second.nchannels = max_channel_count_;
 		}
 
 		// Process boardValid: delete boards that are invalid. This

--- a/gcp/src/GCPMuxDataDecoder.cxx
+++ b/gcp/src/GCPMuxDataDecoder.cxx
@@ -322,8 +322,10 @@ GCPMuxDataDecoder::Process(G3FramePtr frame, std::deque<G3FramePtr> &out_queue)
 		}
 
 		// Set nmodules to avoid triggering warnings
-		for (auto j = metasample->begin(); j != metasample->end(); j++)
+		for (auto j = metasample->begin(); j != metasample->end(); j++) {
 			j->second.nmodules = j->second.size();
+			j->second.nblocks = 1;
+		}
 
 		// Process boardValid: delete boards that are invalid. This
 		// corresponds to the standard missing board signalling in


### PR DESCRIPTION
* Configurable internal clock rate to ensure that the IceBoard sub-second counter can be converted to a proper timestamp
* IceBoard packets indexed by module and sub-module block
* Add `center_frequency` and `bandwidth` attributes to `BolometerProperties` objects, to differentiate between the actual mm-wave observing frequency of the resonator and the band into which channels would be binned during mapmaking.