### PR TITLE
Print core logging messages with timestamps by default

### DIFF
--- a/core/src/G3PrintfLogger.cxx
+++ b/core/src/G3PrintfLogger.cxx
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 G3PrintfLogger::G3PrintfLogger(G3LogLevel level)
-    : G3Logger(level), TrimFileNames(true), Timestamps(false)
+    : G3Logger(level), TrimFileNames(true), Timestamps(true)
 {
 	tty_ = isatty(STDERR_FILENO);
 }


### PR DESCRIPTION
Timestamps on core logging messages are very useful for rudimentary profiling, especially for long running scripts. While the profile option for G3Pipeline.Run() provides similar functionality, it's only useful for scripts that are entirely pipeline-based, which is often not the case. Moreover, timestamps on log messages make it easy to track the progress of a script in real-time, rather than waiting until it has finished running to find out how long it took.

Closes #50.