### PR TITLE
Healpix maps with nside > 8192

### DIFF
--- a/maps/include/maps/FlatSkyMap.h
+++ b/maps/include/maps/FlatSkyMap.h
@@ -112,13 +112,13 @@ public:
 	double yres() const;
 	double res() const;
 
-	ssize_t AngleToPixel(double alpha, double delta) const override;
+	size_t AngleToPixel(double alpha, double delta) const override;
 	std::vector<double> PixelToAngle(size_t pixel) const override;
 	std::vector<double> PixelToAngle(size_t x_pix, size_t y_pix) const;
 	std::vector<double> PixelToAngleWrapRa(size_t pixel) const;
 	std::vector<double> AngleToXY(double alpha, double delta) const;
 	std::vector<double> XYToAngle(double x, double y) const;
-	ssize_t XYToPixel(double x, double y) const;
+	size_t XYToPixel(double x, double y) const;
 	std::vector<double> PixelToXY(size_t pixel) const;
 	std::vector<double> QuatToXY(quat q) const;
 	quat XYToQuat(double x, double y) const;

--- a/maps/include/maps/FlatSkyMap.h
+++ b/maps/include/maps/FlatSkyMap.h
@@ -112,25 +112,25 @@ public:
 	double yres() const;
 	double res() const;
 
-	size_t AngleToPixel(double alpha, double delta) const override;
+	ssize_t AngleToPixel(double alpha, double delta) const override;
 	std::vector<double> PixelToAngle(size_t pixel) const override;
 	std::vector<double> PixelToAngle(size_t x_pix, size_t y_pix) const;
 	std::vector<double> PixelToAngleWrapRa(size_t pixel) const;
 	std::vector<double> AngleToXY(double alpha, double delta) const;
 	std::vector<double> XYToAngle(double x, double y) const;
-	size_t XYToPixel(double x, double y) const;
+	ssize_t XYToPixel(double x, double y) const;
 	std::vector<double> PixelToXY(size_t pixel) const;
 	std::vector<double> QuatToXY(quat q) const;
 	quat XYToQuat(double x, double y) const;
 
 	std::vector<double> PixelToAngleGrad(size_t pixel, double h=0.001) const;
 
-	void GetRebinAngles(long pixel, size_t scale,
+	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const override;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<long> & pixels, std::vector<double> & weights) const override;
+	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const override;
 
-	std::vector<long> QueryDisc(double alpha, double delta,
+	std::vector<ssize_t> QueryDisc(double alpha, double delta,
 	    double radius) const override;
 
 	G3SkyMapPtr Rebin(size_t scale, bool norm = true) const override;

--- a/maps/include/maps/FlatSkyMap.h
+++ b/maps/include/maps/FlatSkyMap.h
@@ -128,9 +128,9 @@ public:
 	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const override;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const override;
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const override;
 
-	std::vector<ssize_t> QueryDisc(double alpha, double delta,
+	std::vector<size_t> QueryDisc(double alpha, double delta,
 	    double radius) const override;
 
 	G3SkyMapPtr Rebin(size_t scale, bool norm = true) const override;

--- a/maps/include/maps/FlatSkyProjection.h
+++ b/maps/include/maps/FlatSkyProjection.h
@@ -85,25 +85,25 @@ public:
 	double yres() const { return y_res_; };
 	double res() const { return y_res_; };
 
-	long XYToPixel(double x, double y) const;
-	std::vector<double> PixelToXY(long pixel) const;
+	ssize_t XYToPixel(double x, double y) const;
+	std::vector<double> PixelToXY(size_t pixel) const;
 	std::vector<double> XYToAngle(double x, double y, bool wrap_alpha=false) const;
 	std::vector<double> AngleToXY(double alpha, double delta) const;
-	std::vector<double> PixelToAngle(long pixel, bool wrap_alpha=false) const;
-	long AngleToPixel(double alpha, double delta) const;
+	std::vector<double> PixelToAngle(size_t pixel, bool wrap_alpha=false) const;
+	ssize_t AngleToPixel(double alpha, double delta) const;
 	std::vector<double> QuatToXY(quat q, bool local) const;
 	quat XYToQuat(double x, double y, bool local) const;
 
 	std::vector<double> XYToAngleGrad(double x, double y, double h=0.001) const;
-	std::vector<double> PixelToAngleGrad(long pixel, double h=0.001) const;
+	std::vector<double> PixelToAngleGrad(size_t pixel, double h=0.001) const;
 
-	void GetRebinAngles(long pixel, size_t scale,
+	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas,
 	    bool wrap_alpha=false) const;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<long> & pixels, std::vector<double> & weights) const;
+	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const;
 
-	std::vector<long> QueryDisc(double alpha, double delta, double radius,
+	std::vector<ssize_t> QueryDisc(double alpha, double delta, double radius,
 	    bool local) const;
 
 	FlatSkyProjection Rebin(size_t scale, double x_center = 0.0 / 0.0,

--- a/maps/include/maps/FlatSkyProjection.h
+++ b/maps/include/maps/FlatSkyProjection.h
@@ -85,12 +85,12 @@ public:
 	double yres() const { return y_res_; };
 	double res() const { return y_res_; };
 
-	ssize_t XYToPixel(double x, double y) const;
+	size_t XYToPixel(double x, double y) const;
 	std::vector<double> PixelToXY(size_t pixel) const;
 	std::vector<double> XYToAngle(double x, double y, bool wrap_alpha=false) const;
 	std::vector<double> AngleToXY(double alpha, double delta) const;
 	std::vector<double> PixelToAngle(size_t pixel, bool wrap_alpha=false) const;
-	ssize_t AngleToPixel(double alpha, double delta) const;
+	size_t AngleToPixel(double alpha, double delta) const;
 	std::vector<double> QuatToXY(quat q, bool local) const;
 	quat XYToQuat(double x, double y, bool local) const;
 

--- a/maps/include/maps/FlatSkyProjection.h
+++ b/maps/include/maps/FlatSkyProjection.h
@@ -97,6 +97,8 @@ public:
 	std::vector<double> XYToAngleGrad(double x, double y, double h=0.001) const;
 	std::vector<double> PixelToAngleGrad(size_t pixel, double h=0.001) const;
 
+	size_t RebinPixel(size_t pixel, size_t scale) const;
+
 	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas,
 	    bool wrap_alpha=false) const;

--- a/maps/include/maps/FlatSkyProjection.h
+++ b/maps/include/maps/FlatSkyProjection.h
@@ -103,9 +103,9 @@ public:
 	    std::vector<double> & alphas, std::vector<double> & deltas,
 	    bool wrap_alpha=false) const;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const;
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const;
 
-	std::vector<ssize_t> QueryDisc(double alpha, double delta, double radius,
+	std::vector<size_t> QueryDisc(double alpha, double delta, double radius,
 	    bool local) const;
 
 	FlatSkyProjection Rebin(size_t scale, double x_center = 0.0 / 0.0,

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -172,10 +172,10 @@ public:
 	    std::vector<double> & alphas, std::vector<double> & deltas) const = 0;
 	G3VectorQuat GetRebinQuats(size_t pixel, size_t scale) const;
 	virtual void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const = 0;
-	void GetInterpPixelsWeights(quat q, std::vector<ssize_t> & pixels,
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const = 0;
+	void GetInterpPixelsWeights(quat q, std::vector<size_t> & pixels,
 	    std::vector<double> & weights) const;
-	double GetInterpPrecalc(const std::vector<ssize_t> &pixels,
+	double GetInterpPrecalc(const std::vector<size_t> &pixels,
 	    const std::vector<double> &weights) const;
 	double GetInterpValue(double alpha, double delta) const;
 	double GetInterpValue(quat q) const;
@@ -186,10 +186,10 @@ public:
 	virtual boost::shared_ptr<G3SkyMap> Rebin(size_t scale, bool norm = true) const = 0;
 
 	/* Analogue to healpy.query_disc, returns list of pixels within a disc */
-	virtual std::vector<ssize_t> QueryDisc(double alpha, double delta, double radius) const {
+	virtual std::vector<size_t> QueryDisc(double alpha, double delta, double radius) const {
 		throw std::runtime_error("QueryDisc not implemented");
 	};
-	std::vector<ssize_t> QueryAlphaEllipse(double alpha, double delta, double a, double b) const;
+	std::vector<size_t> QueryAlphaEllipse(double alpha, double delta, double a, double b) const;
 
 	virtual bool IsDense() const {
 		throw std::runtime_error("Checking array density not implemented");

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -155,27 +155,27 @@ public:
 	virtual void ApplyMask(const G3SkyMapMask &mask, bool inverse=false);
 
 	// Pointing information
-	std::vector<size_t> AnglesToPixels(const std::vector<double> & alphas,
+	std::vector<ssize_t> AnglesToPixels(const std::vector<double> & alphas,
 	    const std::vector<double> & deltas) const;
 	void PixelsToAngles(const std::vector<size_t> & pixels,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
-	std::vector<size_t> QuatsToPixels(const G3VectorQuat &quats) const;
+	std::vector<ssize_t> QuatsToPixels(const G3VectorQuat &quats) const;
 	G3VectorQuat PixelsToQuats(const std::vector<size_t> &pixels) const;
 
 	virtual std::vector<double> PixelToAngle(size_t pixel) const = 0;
-	virtual size_t AngleToPixel(double alpha, double delta) const = 0;
+	virtual ssize_t AngleToPixel(double alpha, double delta) const = 0;
 	quat PixelToQuat(size_t pixel) const;
-	size_t QuatToPixel(quat q) const;
+	ssize_t QuatToPixel(quat q) const;
 
 	// Rebinning and interpolation
-	virtual void GetRebinAngles(long pixel, size_t scale,
+	virtual void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const = 0;
-	G3VectorQuat GetRebinQuats(long pixel, size_t scale) const;
+	G3VectorQuat GetRebinQuats(size_t pixel, size_t scale) const;
 	virtual void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<long> & pixels, std::vector<double> & weights) const = 0;
-	void GetInterpPixelsWeights(quat q, std::vector<long> & pixels,
+	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const = 0;
+	void GetInterpPixelsWeights(quat q, std::vector<ssize_t> & pixels,
 	    std::vector<double> & weights) const;
-	double GetInterpPrecalc(const std::vector<long> &pixels,
+	double GetInterpPrecalc(const std::vector<ssize_t> &pixels,
 	    const std::vector<double> &weights) const;
 	double GetInterpValue(double alpha, double delta) const;
 	double GetInterpValue(quat q) const;
@@ -186,10 +186,10 @@ public:
 	virtual boost::shared_ptr<G3SkyMap> Rebin(size_t scale, bool norm = true) const = 0;
 
 	/* Analogue to healpy.query_disc, returns list of pixels within a disc */
-	virtual std::vector<long> QueryDisc(double alpha, double delta, double radius) const {
+	virtual std::vector<ssize_t> QueryDisc(double alpha, double delta, double radius) const {
 		throw std::runtime_error("QueryDisc not implemented");
 	};
-	std::vector<long> QueryAlphaEllipse(double alpha, double delta, double a, double b) const;
+	std::vector<ssize_t> QueryAlphaEllipse(double alpha, double delta, double a, double b) const;
 
 	virtual bool IsDense() const {
 		throw std::runtime_error("Checking array density not implemented");

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -155,17 +155,17 @@ public:
 	virtual void ApplyMask(const G3SkyMapMask &mask, bool inverse=false);
 
 	// Pointing information
-	std::vector<ssize_t> AnglesToPixels(const std::vector<double> & alphas,
+	std::vector<size_t> AnglesToPixels(const std::vector<double> & alphas,
 	    const std::vector<double> & deltas) const;
 	void PixelsToAngles(const std::vector<size_t> & pixels,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
-	std::vector<ssize_t> QuatsToPixels(const G3VectorQuat &quats) const;
+	std::vector<size_t> QuatsToPixels(const G3VectorQuat &quats) const;
 	G3VectorQuat PixelsToQuats(const std::vector<size_t> &pixels) const;
 
 	virtual std::vector<double> PixelToAngle(size_t pixel) const = 0;
-	virtual ssize_t AngleToPixel(double alpha, double delta) const = 0;
+	virtual size_t AngleToPixel(double alpha, double delta) const = 0;
 	quat PixelToQuat(size_t pixel) const;
-	ssize_t QuatToPixel(quat q) const;
+	size_t QuatToPixel(quat q) const;
 
 	// Rebinning and interpolation
 	virtual void GetRebinAngles(size_t pixel, size_t scale,

--- a/maps/include/maps/HealpixSkyMap.h
+++ b/maps/include/maps/HealpixSkyMap.h
@@ -84,9 +84,9 @@ public:
 	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const override;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const override;
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const override;
 
-	std::vector<ssize_t> QueryDisc(double alpha, double delta,
+	std::vector<size_t> QueryDisc(double alpha, double delta,
 	    double radius) const override;
 
 	G3SkyMapPtr Rebin(size_t scale, bool norm = true) const override;

--- a/maps/include/maps/HealpixSkyMap.h
+++ b/maps/include/maps/HealpixSkyMap.h
@@ -78,7 +78,7 @@ public:
 	bool nested() const {return info_.nested();}
 	double res() const;
 
-	ssize_t AngleToPixel(double alpha, double delta) const override;
+	size_t AngleToPixel(double alpha, double delta) const override;
 	std::vector<double> PixelToAngle(size_t pixel) const override;
 
 	void GetRebinAngles(size_t pixel, size_t scale,

--- a/maps/include/maps/HealpixSkyMap.h
+++ b/maps/include/maps/HealpixSkyMap.h
@@ -78,15 +78,15 @@ public:
 	bool nested() const {return info_.nested();}
 	double res() const;
 
-	size_t AngleToPixel(double alpha, double delta) const override;
+	ssize_t AngleToPixel(double alpha, double delta) const override;
 	std::vector<double> PixelToAngle(size_t pixel) const override;
 
-	void GetRebinAngles(long pixel, size_t scale,
+	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const override;
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<long> & pixels, std::vector<double> & weights) const override;
+	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const override;
 
-	std::vector<long> QueryDisc(double alpha, double delta,
+	std::vector<ssize_t> QueryDisc(double alpha, double delta,
 	    double radius) const override;
 
 	G3SkyMapPtr Rebin(size_t scale, bool norm = true) const override;

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -32,13 +32,13 @@ public:
 	bool shifted() const { return shifted_; }
 	double res() const;
 
-	std::pair<ssize_t, ssize_t> PixelToRing(ssize_t pix) const;
-	ssize_t RingToPixel(ssize_t iring, ssize_t ringpix) const;
+	std::pair<size_t, size_t> PixelToRing(size_t pix) const;
+	size_t RingToPixel(size_t iring, size_t ringpix) const;
 
 	std::vector<double> PixelToAngle(size_t pixel) const;
 	ssize_t AngleToPixel(double alpha, double delta) const;
 
-	void GetRebinAngles(ssize_t pixel, size_t scale,
+	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
 
 	void GetInterpPixelsWeights(double alpha, double delta,

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -33,18 +33,18 @@ public:
 	double res() const;
 
 	std::pair<size_t, size_t> PixelToRing(size_t pix) const;
-	size_t RingToPixel(size_t iring, size_t ringpix) const;
+	ssize_t RingToPixel(size_t iring, size_t ringpix) const;
 
 	std::vector<double> PixelToAngle(size_t pixel) const;
-	size_t AngleToPixel(double alpha, double delta) const;
+	ssize_t AngleToPixel(double alpha, double delta) const;
 
-	void GetRebinAngles(long pixel, size_t scale,
+	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
 
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<long> & pixels, std::vector<double> & weights) const;
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const;
 
-	std::vector<long> QueryDisc(double alpha, double delta,
+	std::vector<ssize_t> QueryDisc(double alpha, double delta,
 	    double radius) const;
 
 private:

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -36,7 +36,7 @@ public:
 	size_t RingToPixel(size_t iring, size_t ringpix) const;
 
 	std::vector<double> PixelToAngle(size_t pixel) const;
-	ssize_t AngleToPixel(double alpha, double delta) const;
+	size_t AngleToPixel(double alpha, double delta) const;
 
 	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
@@ -68,7 +68,7 @@ private:
 
 	std::vector<HealpixRingInfo> rings_;
 
-	ssize_t RingAbove(double z) const;
+	size_t RingAbove(double z) const;
 
 	SET_LOGGER("HealpixSkyMapInfo");
 };

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -14,7 +14,8 @@ public:
 	HealpixSkyMapInfo();
 	HealpixSkyMapInfo(const HealpixSkyMapInfo& info);
 
-	void initialize(size_t nside, bool nested=false, bool shifted=false);
+	void initialize(size_t nside_or_npix, bool nested=false,
+	    bool shifted=false, bool is_npix=false);
 
 	template <class A> void load(A &ar, unsigned v);
 	template <class A> void save(A &ar, unsigned v) const;
@@ -22,6 +23,7 @@ public:
 	std::string Description() const override;
 
 	void SetNSide(size_t nside);
+	void SetNPix(size_t npix);
 	void SetNested(bool nested);
 	void SetShifted(bool shifted);
 

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -38,6 +38,8 @@ public:
 	std::vector<double> PixelToAngle(size_t pixel) const;
 	size_t AngleToPixel(double alpha, double delta) const;
 
+	size_t RebinPixel(size_t pixel, size_t scale) const;
+
 	void GetRebinAngles(size_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
 

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -46,9 +46,9 @@ public:
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
 
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const;
+	    std::vector<size_t> & pixels, std::vector<double> & weights) const;
 
-	std::vector<ssize_t> QueryDisc(double alpha, double delta,
+	std::vector<size_t> QueryDisc(double alpha, double delta,
 	    double radius) const;
 
 private:

--- a/maps/include/maps/HealpixSkyMapInfo.h
+++ b/maps/include/maps/HealpixSkyMapInfo.h
@@ -32,17 +32,17 @@ public:
 	bool shifted() const { return shifted_; }
 	double res() const;
 
-	std::pair<size_t, size_t> PixelToRing(size_t pix) const;
-	ssize_t RingToPixel(size_t iring, size_t ringpix) const;
+	std::pair<ssize_t, ssize_t> PixelToRing(ssize_t pix) const;
+	ssize_t RingToPixel(ssize_t iring, ssize_t ringpix) const;
 
 	std::vector<double> PixelToAngle(size_t pixel) const;
 	ssize_t AngleToPixel(double alpha, double delta) const;
 
-	void GetRebinAngles(size_t pixel, size_t scale,
+	void GetRebinAngles(ssize_t pixel, size_t scale,
 	    std::vector<double> & alphas, std::vector<double> & deltas) const;
 
 	void GetInterpPixelsWeights(double alpha, double delta,
-	    std::vector<size_t> & pixels, std::vector<double> & weights) const;
+	    std::vector<ssize_t> & pixels, std::vector<double> & weights) const;
 
 	std::vector<ssize_t> QueryDisc(double alpha, double delta,
 	    double radius) const;
@@ -68,7 +68,7 @@ private:
 
 	std::vector<HealpixRingInfo> rings_;
 
-	size_t RingAbove(double z) const;
+	ssize_t RingAbove(double z) const;
 
 	SET_LOGGER("HealpixSkyMapInfo");
 };

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -780,9 +780,7 @@ G3SkyMapPtr FlatSkyMap::Rebin(size_t scale, bool norm) const
 	for (auto i : *this) {
 		if (i.second == 0)
 			continue;
-		size_t x = (i.first % xpix_) / scale;
-		size_t y = ((size_t)(i.first / xpix_)) / scale;
-		size_t ip = x + y * out->xpix_;
+		size_t ip = proj_info.RebinPixel(i.first, scale);
 		(*out)[ip] += i.second / sqscal;
 	}
 

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -696,7 +696,7 @@ std::vector<double> FlatSkyMap::XYToAngle(double x, double y) const {
 	return proj_info.XYToAngle(x, y, false);
 }
 
-size_t
+ssize_t
 FlatSkyMap::XYToPixel(double x, double y) const {
 	return proj_info.XYToPixel(x, y);
 }
@@ -718,7 +718,7 @@ FlatSkyMap::XYToQuat(double x, double y) const
 	return proj_info.XYToQuat(x, y, coord_ref == Local);
 }
 
-size_t FlatSkyMap::AngleToPixel(double alpha, double delta) const {
+ssize_t FlatSkyMap::AngleToPixel(double alpha, double delta) const {
 	return proj_info.AngleToPixel(alpha, delta);
 }
 
@@ -738,19 +738,19 @@ std::vector<double> FlatSkyMap::PixelToAngleGrad(size_t pixel, double h) const {
 	return proj_info.PixelToAngleGrad(pixel, h);
 }
 
-void FlatSkyMap::GetRebinAngles(long pixel, size_t scale,
+void FlatSkyMap::GetRebinAngles(size_t pixel, size_t scale,
     std::vector<double> & alphas, std::vector<double> & deltas) const
 {
 	proj_info.GetRebinAngles(pixel, scale, alphas, deltas, false);
 }
 
 void FlatSkyMap::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<long> & pixels, std::vector<double> & weights) const
+    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
 {
 	proj_info.GetInterpPixelsWeights(alpha, delta, pixels, weights);
 }
 
-std::vector<long>
+std::vector<ssize_t>
 FlatSkyMap::QueryDisc(double alpha, double delta, double radius) const
 {
 	return proj_info.QueryDisc(alpha, delta, radius, coord_ref == Local);
@@ -1161,13 +1161,13 @@ flatskymap_pixels_to_xy(const FlatSkyMap & skymap, const std::vector<size_t> &pi
 	return boost::python::make_tuple(x, y);
 }
 
-static std::vector<size_t>
+static std::vector<ssize_t>
 flatskymap_xy_to_pixels(const FlatSkyMap & skymap, const std::vector<double> &x,
     const std::vector<double> &y)
 {
 	g3_assert(x.size() == y.size());
 
-	std::vector<size_t> pixel(x.size());
+	std::vector<ssize_t> pixel(x.size());
 	for (size_t i = 0; i < x.size(); i++) {
 		pixel[i] = skymap.XYToPixel(x[i], y[i]);
 	}

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -745,12 +745,12 @@ void FlatSkyMap::GetRebinAngles(size_t pixel, size_t scale,
 }
 
 void FlatSkyMap::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
+    std::vector<size_t> & pixels, std::vector<double> & weights) const
 {
 	proj_info.GetInterpPixelsWeights(alpha, delta, pixels, weights);
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 FlatSkyMap::QueryDisc(double alpha, double delta, double radius) const
 {
 	return proj_info.QueryDisc(alpha, delta, radius, coord_ref == Local);

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -696,7 +696,7 @@ std::vector<double> FlatSkyMap::XYToAngle(double x, double y) const {
 	return proj_info.XYToAngle(x, y, false);
 }
 
-ssize_t
+size_t
 FlatSkyMap::XYToPixel(double x, double y) const {
 	return proj_info.XYToPixel(x, y);
 }
@@ -718,7 +718,7 @@ FlatSkyMap::XYToQuat(double x, double y) const
 	return proj_info.XYToQuat(x, y, coord_ref == Local);
 }
 
-ssize_t FlatSkyMap::AngleToPixel(double alpha, double delta) const {
+size_t FlatSkyMap::AngleToPixel(double alpha, double delta) const {
 	return proj_info.AngleToPixel(alpha, delta);
 }
 
@@ -1161,13 +1161,13 @@ flatskymap_pixels_to_xy(const FlatSkyMap & skymap, const std::vector<size_t> &pi
 	return boost::python::make_tuple(x, y);
 }
 
-static std::vector<ssize_t>
+static std::vector<size_t>
 flatskymap_xy_to_pixels(const FlatSkyMap & skymap, const std::vector<double> &x,
     const std::vector<double> &y)
 {
 	g3_assert(x.size() == y.size());
 
-	std::vector<ssize_t> pixel(x.size());
+	std::vector<size_t> pixel(x.size());
 	for (size_t i = 0; i < x.size(); i++) {
 		pixel[i] = skymap.XYToPixel(x[i], y[i]);
 	}

--- a/maps/src/FlatSkyProjection.cxx
+++ b/maps/src/FlatSkyProjection.cxx
@@ -247,7 +247,7 @@ void FlatSkyProjection::SetRes(double res, double x_res)
 	SetXRes(x_res);
 }
 
-ssize_t
+size_t
 FlatSkyProjection::XYToPixel(double x, double y) const
 {
 	// Truncate X/Y coordinates to integer pixels and wrap to 1D.
@@ -552,7 +552,7 @@ FlatSkyProjection::PixelToAngle(size_t pixel, bool wrap_alpha) const
 	return XYToAngle(xy[0], xy[1], wrap_alpha);
 }
 
-ssize_t
+size_t
 FlatSkyProjection::AngleToPixel(double alpha, double delta) const
 {
 	std::vector<double> xy = AngleToXY(alpha, delta);

--- a/maps/src/FlatSkyProjection.cxx
+++ b/maps/src/FlatSkyProjection.cxx
@@ -629,19 +629,19 @@ FlatSkyProjection::PixelToAngleGrad(size_t pixel, double h) const
 }
 
 void FlatSkyProjection::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
+    std::vector<size_t> & pixels, std::vector<double> & weights) const
 {
 	std::vector<double> xy = AngleToXY(alpha, delta);
 	double x = xy[0];
 	double y = xy[1];
 
-	pixels = std::vector<ssize_t>(4, -1);
+	pixels = std::vector<size_t>(4, (size_t) -1);
 	weights = std::vector<double>(4, 0);
 
-	int x_1 = (int)floorf(x);
-	int x_2 = x_1 + 1;
-	int y_1 = (int)floorf(y);
-	int y_2 = y_1 + 1;
+	ssize_t x_1 = (ssize_t)floorf(x);
+	ssize_t x_2 = x_1 + 1;
+	ssize_t y_1 = (ssize_t)floorf(y);
+	ssize_t y_2 = y_1 + 1;
 	if (x_1 < 0 || y_1 < 0 || x_2 >= xpix_ || y_2 >= ypix_){
 		log_debug("Point lies outside of pixel grid\n");
 		return;
@@ -653,7 +653,7 @@ void FlatSkyProjection::GetInterpPixelsWeights(double alpha, double delta,
 	pixels[3] = x_2 + y_2 * xpix_;  weights[3] = (x - x_1) * (y - y_1);
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool local) const
 {
 	static const size_t npts = 72;
@@ -701,10 +701,10 @@ FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool loc
 			ymax = cy > ypix_ ? ypix_ : cy;
 	}
 
-	std::vector<ssize_t> pixels;
+	std::vector<size_t> pixels;
 	for (size_t x = xmin; x < xmax; x++) {
 		for (size_t y = ymin; y < ymax; y++) {
-			ssize_t pixel = y * xpix_ + x;
+			size_t pixel = y * xpix_ + x;
 			auto ang = PixelToAngle(pixel);
 			if (angular_distance(alpha, delta, ang[0], ang[1]) < radius)
 				pixels.push_back(pixel);

--- a/maps/src/FlatSkyProjection.cxx
+++ b/maps/src/FlatSkyProjection.cxx
@@ -247,7 +247,7 @@ void FlatSkyProjection::SetRes(double res, double x_res)
 	SetXRes(x_res);
 }
 
-long
+ssize_t
 FlatSkyProjection::XYToPixel(double x, double y) const
 {
 	// Truncate X/Y coordinates to integer pixels and wrap to 1D.
@@ -255,20 +255,20 @@ FlatSkyProjection::XYToPixel(double x, double y) const
 	// The floor() is important to properly truncate negative numbers,
 	// which otherwise pile up at zero from both directions.
 
-	long ix = (long)floor(x + 0.5);
-	long iy = (long)floor(y + 0.5);
+	ssize_t ix = (ssize_t)floor(x + 0.5);
+	ssize_t iy = (ssize_t)floor(y + 0.5);
 	return (ix < 0 || iy < 0 || ix >= xpix_ || iy >= ypix_) ?
 	    -1 : ix + iy * xpix_;
 }
 
 std::vector<double>
-FlatSkyProjection::PixelToXY(long pixel) const
+FlatSkyProjection::PixelToXY(size_t pixel) const
 {
 	std::vector<double> out(2, -1);
 
 	if (pixel >= 0 && pixel < xpix_ * ypix_) {
-		out[0] = (int)(pixel % xpix_);
-		out[1] = (int)(pixel / xpix_);
+		out[0] = (ssize_t)(pixel % xpix_);
+		out[1] = (ssize_t)(pixel / xpix_);
 	}
 
 	return out;
@@ -544,7 +544,7 @@ FlatSkyProjection::XYToQuat(double x, double y, bool local) const
 }
 
 std::vector<double>
-FlatSkyProjection::PixelToAngle(long pixel, bool wrap_alpha) const
+FlatSkyProjection::PixelToAngle(size_t pixel, bool wrap_alpha) const
 {
 	if (pixel < 0 || pixel >= xpix_ * ypix_)
 		return {0., 0.};
@@ -552,14 +552,14 @@ FlatSkyProjection::PixelToAngle(long pixel, bool wrap_alpha) const
 	return XYToAngle(xy[0], xy[1], wrap_alpha);
 }
 
-long
+ssize_t
 FlatSkyProjection::AngleToPixel(double alpha, double delta) const
 {
 	std::vector<double> xy = AngleToXY(alpha, delta);
 	return XYToPixel(xy[0], xy[1]);
 }
 
-void FlatSkyProjection::GetRebinAngles(long pixel, size_t scale,
+void FlatSkyProjection::GetRebinAngles(size_t pixel, size_t scale,
     std::vector<double> & alphas, std::vector<double> & deltas,
     bool wrap_alpha) const
 {
@@ -620,7 +620,7 @@ FlatSkyProjection::XYToAngleGrad(double x, double y, double h) const
 }
 
 std::vector<double>
-FlatSkyProjection::PixelToAngleGrad(long pixel, double h) const
+FlatSkyProjection::PixelToAngleGrad(size_t pixel, double h) const
 {
 	if (pixel < 0 || pixel >= xpix_ * ypix_)
 		return {0., 0., 0., 0.};
@@ -629,13 +629,13 @@ FlatSkyProjection::PixelToAngleGrad(long pixel, double h) const
 }
 
 void FlatSkyProjection::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<long> & pixels, std::vector<double> & weights) const
+    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
 {
 	std::vector<double> xy = AngleToXY(alpha, delta);
 	double x = xy[0];
 	double y = xy[1];
 
-	pixels = std::vector<long>(4, -1);
+	pixels = std::vector<ssize_t>(4, -1);
 	weights = std::vector<double>(4, 0);
 
 	int x_1 = (int)floorf(x);
@@ -653,7 +653,7 @@ void FlatSkyProjection::GetInterpPixelsWeights(double alpha, double delta,
 	pixels[3] = x_2 + y_2 * xpix_;  weights[3] = (x - x_1) * (y - y_1);
 }
 
-std::vector<long>
+std::vector<ssize_t>
 FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool local) const
 {
 	static const size_t npts = 72;
@@ -671,10 +671,10 @@ FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool loc
 	double pvb = pv.R_component_3();
 	double pvc = pv.R_component_4();
 
-	long xmin = xpix_;
-	long xmax = 0;
-	long ymin = ypix_;
-	long ymax = 0;
+	ssize_t xmin = xpix_;
+	ssize_t xmax = 0;
+	ssize_t ymin = ypix_;
+	ssize_t ymax = 0;
 
 	double a, d;
 	double phi = 0;
@@ -687,10 +687,10 @@ FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool loc
 		double s = sin(phi / 2.0);
 		quat q = quat(c, pva * s, pvb * s, pvc * s);
 		auto xy = QuatToXY(q * p / q, local);
-		long fx = std::floor(xy[0]);
-		long cx = std::ceil(xy[0]);
-		long fy = std::floor(xy[1]);
-		long cy = std::ceil(xy[1]);
+		ssize_t fx = std::floor(xy[0]);
+		ssize_t cx = std::ceil(xy[0]);
+		ssize_t fy = std::floor(xy[1]);
+		ssize_t cy = std::ceil(xy[1]);
 		if (fx < xmin)
 			xmin = fx < 0 ? 0 : fx;
 		if (cx > xmax)
@@ -701,10 +701,10 @@ FlatSkyProjection::QueryDisc(double alpha, double delta, double radius, bool loc
 			ymax = cy > ypix_ ? ypix_ : cy;
 	}
 
-	std::vector<long> pixels;
+	std::vector<ssize_t> pixels;
 	for (size_t x = xmin; x < xmax; x++) {
 		for (size_t y = ymin; y < ymax; y++) {
-			long pixel = y * xpix_ + x;
+			ssize_t pixel = y * xpix_ + x;
 			auto ang = PixelToAngle(pixel);
 			if (angular_distance(alpha, delta, ang[0], ang[1]) < radius)
 				pixels.push_back(pixel);

--- a/maps/src/FlatSkyProjection.cxx
+++ b/maps/src/FlatSkyProjection.cxx
@@ -738,6 +738,13 @@ FlatSkyProjection FlatSkyProjection::Rebin(size_t scale, double x_center, double
 	return fp;
 }
 
+size_t FlatSkyProjection::RebinPixel(size_t pixel, size_t scale) const
+{
+	size_t x = (pixel % xpix_) / scale;
+	size_t y = ((size_t)(pixel / xpix_)) / scale;
+	return x + y * (xpix_ / scale);
+}
+
 FlatSkyProjection FlatSkyProjection::OverlayPatch(double x0, double y0,
     size_t width, size_t height) const
 {

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -137,11 +137,11 @@ G3SkyMapWeights::G3SkyMapWeights(const G3SkyMapWeights &r, bool copy_data) :
 {
 }
 
-std::vector<size_t>
+std::vector<ssize_t>
 G3SkyMap::AnglesToPixels(const std::vector<double> & alphas,
     const std::vector<double> & deltas) const
 {
-	std::vector<size_t> pixels(alphas.size());
+	std::vector<ssize_t> pixels(alphas.size());
 
 	for (size_t i = 0; i < alphas.size(); i++) {
 		pixels[i] = AngleToPixel(alphas[i], deltas[i]);
@@ -169,7 +169,7 @@ G3SkyMap::PixelsToAngles(const std::vector<size_t> & pixels,
 	}
 }
 
-size_t
+ssize_t
 G3SkyMap::QuatToPixel(quat q) const
 {
 	double alpha, delta;
@@ -190,10 +190,10 @@ G3SkyMap::PixelToQuat(size_t pixel) const
 	return ang_to_quat(alphadelta[0], alphadelta[1]);
 }
 
-std::vector<size_t>
+std::vector<ssize_t>
 G3SkyMap::QuatsToPixels(const G3VectorQuat &quats) const
 {
-	std::vector<size_t> pixels(quats.size());
+	std::vector<ssize_t> pixels(quats.size());
 	for (size_t i = 0; i < quats.size(); i++)
 		pixels[i] = QuatToPixel(quats[i]);
 
@@ -334,7 +334,7 @@ G3SkyMap &G3SkyMap::operator/=(double rhs)
 
 
 void
-G3SkyMap::GetInterpPixelsWeights(quat q, std::vector<long> & pixels,
+G3SkyMap::GetInterpPixelsWeights(quat q, std::vector<ssize_t> & pixels,
     std::vector<double> & weights) const
 {
 	double alpha, delta;
@@ -346,7 +346,7 @@ G3SkyMap::GetInterpPixelsWeights(quat q, std::vector<long> & pixels,
 }
 
 G3VectorQuat
-G3SkyMap::GetRebinQuats(long pixel, size_t scale) const
+G3SkyMap::GetRebinQuats(size_t pixel, size_t scale) const
 {
 	std::vector<double> alphas, deltas;
 
@@ -363,7 +363,7 @@ G3SkyMap::GetRebinQuats(long pixel, size_t scale) const
 }
 
 double
-G3SkyMap::GetInterpPrecalc(const std::vector<long> & pix,
+G3SkyMap::GetInterpPrecalc(const std::vector<ssize_t> & pix,
     const std::vector<double> & weight) const
 {
 	double outval = 0;
@@ -376,7 +376,7 @@ G3SkyMap::GetInterpPrecalc(const std::vector<long> & pix,
 double
 G3SkyMap::GetInterpValue(double alpha, double delta) const
 {
-	std::vector<long> pix;
+	std::vector<ssize_t> pix;
 	std::vector<double> weight;
 	GetInterpPixelsWeights(alpha, delta, pix, weight);
 	return GetInterpPrecalc(pix, weight);
@@ -417,7 +417,7 @@ G3SkyMap::GetInterpValues(const G3VectorQuat & quats) const
 	return outvals;
 }
 
-std::vector<long>
+std::vector<ssize_t>
 G3SkyMap::QueryAlphaEllipse(double alpha, double delta, double a, double b) const
 {
 	double rmaj = a > b ? a : b;
@@ -428,7 +428,7 @@ G3SkyMap::QueryAlphaEllipse(double alpha, double delta, double a, double b) cons
 
 	auto disc = QueryDisc(alpha, delta, rmaj);
 
-	std::vector<long> pixels;
+	std::vector<ssize_t> pixels;
 	for (auto i: disc) {
 		auto ang = PixelToAngle(i);
 		double d = angular_distance(ang[0], ang[1], ahi, delta) +
@@ -441,7 +441,7 @@ G3SkyMap::QueryAlphaEllipse(double alpha, double delta, double a, double b) cons
 }
 
 static double
-skymap_getitem(const G3SkyMap &skymap, int i)
+skymap_getitem(const G3SkyMap &skymap, ssize_t i)
 {
 
 	if (i < 0)
@@ -455,7 +455,7 @@ skymap_getitem(const G3SkyMap &skymap, int i)
 }
 
 static void
-skymap_setitem(G3SkyMap &skymap, int i, double val)
+skymap_setitem(G3SkyMap &skymap, ssize_t i, double val)
 {
 
 	if (i < 0)

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -334,7 +334,7 @@ G3SkyMap &G3SkyMap::operator/=(double rhs)
 
 
 void
-G3SkyMap::GetInterpPixelsWeights(quat q, std::vector<ssize_t> & pixels,
+G3SkyMap::GetInterpPixelsWeights(quat q, std::vector<size_t> & pixels,
     std::vector<double> & weights) const
 {
 	double alpha, delta;
@@ -363,7 +363,7 @@ G3SkyMap::GetRebinQuats(size_t pixel, size_t scale) const
 }
 
 double
-G3SkyMap::GetInterpPrecalc(const std::vector<ssize_t> & pix,
+G3SkyMap::GetInterpPrecalc(const std::vector<size_t> & pix,
     const std::vector<double> & weight) const
 {
 	double outval = 0;
@@ -376,7 +376,7 @@ G3SkyMap::GetInterpPrecalc(const std::vector<ssize_t> & pix,
 double
 G3SkyMap::GetInterpValue(double alpha, double delta) const
 {
-	std::vector<ssize_t> pix;
+	std::vector<size_t> pix;
 	std::vector<double> weight;
 	GetInterpPixelsWeights(alpha, delta, pix, weight);
 	return GetInterpPrecalc(pix, weight);
@@ -417,7 +417,7 @@ G3SkyMap::GetInterpValues(const G3VectorQuat & quats) const
 	return outvals;
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 G3SkyMap::QueryAlphaEllipse(double alpha, double delta, double a, double b) const
 {
 	double rmaj = a > b ? a : b;
@@ -428,7 +428,7 @@ G3SkyMap::QueryAlphaEllipse(double alpha, double delta, double a, double b) cons
 
 	auto disc = QueryDisc(alpha, delta, rmaj);
 
-	std::vector<ssize_t> pixels;
+	std::vector<size_t> pixels;
 	for (auto i: disc) {
 		auto ang = PixelToAngle(i);
 		double d = angular_distance(ang[0], ang[1], ahi, delta) +

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -137,11 +137,11 @@ G3SkyMapWeights::G3SkyMapWeights(const G3SkyMapWeights &r, bool copy_data) :
 {
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 G3SkyMap::AnglesToPixels(const std::vector<double> & alphas,
     const std::vector<double> & deltas) const
 {
-	std::vector<ssize_t> pixels(alphas.size());
+	std::vector<size_t> pixels(alphas.size());
 
 	for (size_t i = 0; i < alphas.size(); i++) {
 		pixels[i] = AngleToPixel(alphas[i], deltas[i]);
@@ -169,7 +169,7 @@ G3SkyMap::PixelsToAngles(const std::vector<size_t> & pixels,
 	}
 }
 
-ssize_t
+size_t
 G3SkyMap::QuatToPixel(quat q) const
 {
 	double alpha, delta;
@@ -190,10 +190,10 @@ G3SkyMap::PixelToQuat(size_t pixel) const
 	return ang_to_quat(alphadelta[0], alphadelta[1]);
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 G3SkyMap::QuatsToPixels(const G3VectorQuat &quats) const
 {
-	std::vector<ssize_t> pixels(quats.size());
+	std::vector<size_t> pixels(quats.size());
 	for (size_t i = 0; i < quats.size(); i++)
 		pixels[i] = QuatToPixel(quats[i]);
 

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -996,7 +996,7 @@ size_t HealpixSkyMap::NpixNonZero() const
 	return sz;
 }
 
-ssize_t
+size_t
 HealpixSkyMap::AngleToPixel(double alpha, double delta) const
 {
 	return info_.AngleToPixel(alpha, delta);

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -8,7 +8,7 @@
 
 #include <G3Units.h>
 #include <maps/HealpixSkyMap.h>
-#include <maps/chealpix.h>
+#include "chealpix.h"
 #include <maps/G3SkyMapMask.h>
 
 #include "mapdata.h"

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -728,7 +728,6 @@ G3SkyMap &HealpixSkyMap::operator /=(const G3SkyMap &rhs) {
 			} else
 				zero = true;
 		} else if (ring_sparse_) {
-			long i = 0;
 			if (b.dense_ || b.ring_sparse_ || b.indexed_sparse_) {
 				for (size_t i = 0; i < size(); i++) {
 					double valb = b.at(i);
@@ -1009,7 +1008,7 @@ HealpixSkyMap::PixelToAngle(size_t pixel) const
 	return info_.PixelToAngle(pixel);
 }
 
-void HealpixSkyMap::GetRebinAngles(long pixel, size_t scale,
+void HealpixSkyMap::GetRebinAngles(size_t pixel, size_t scale,
     std::vector<double> & alphas, std::vector<double> & deltas) const
 {
 	info_.GetRebinAngles(pixel, scale, alphas, deltas);
@@ -1017,12 +1016,12 @@ void HealpixSkyMap::GetRebinAngles(long pixel, size_t scale,
 
 void
 HealpixSkyMap::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<long> & pixels, std::vector<double> & weights) const
+    std::vector<size_t> & pixels, std::vector<double> & weights) const
 {
 	info_.GetInterpPixelsWeights(alpha, delta, pixels, weights);
 }
 
-std::vector<long>
+std::vector<ssize_t>
 HealpixSkyMap::QueryDisc(double alpha, double delta, double radius) const
 {
 	return info_.QueryDisc(alpha, delta, radius);
@@ -1054,12 +1053,12 @@ G3SkyMapPtr HealpixSkyMap::Rebin(size_t scale, bool norm) const
 	for (auto i : *this) {
 		if (i.second == 0)
 			continue;
-		long ip = i.first;
+		size_t ip = i.first;
 		if (!nested())
-			ring2nest(nside(), ip, &ip);
+			ring2nest64(nside(), ip, &ip);
 		ip /= scale2;
 		if (!nested())
-			nest2ring(out->nside(), ip, &ip);
+			nest2ring64(out->nside(), ip, &ip);
 		(*out)[ip] += i.second / sqscal;
 	}
 

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -1015,12 +1015,12 @@ void HealpixSkyMap::GetRebinAngles(size_t pixel, size_t scale,
 
 void
 HealpixSkyMap::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
+    std::vector<size_t> & pixels, std::vector<double> & weights) const
 {
 	info_.GetInterpPixelsWeights(alpha, delta, pixels, weights);
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 HealpixSkyMap::QueryDisc(double alpha, double delta, double radius) const
 {
 	return info_.QueryDisc(alpha, delta, radius);

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -1047,18 +1047,12 @@ G3SkyMapPtr HealpixSkyMap::Rebin(size_t scale, bool norm) const
 	else
 		return out;
 
-	const size_t scale2 = scale * scale;
-	const double sqscal = norm ? scale2 : 1.0;
+	const double sqscal = norm ? scale * scale : 1.0;
 
 	for (auto i : *this) {
 		if (i.second == 0)
 			continue;
-		ssize_t ip = i.first;
-		if (!nested())
-			ring2nest64(nside(), ip, &ip);
-		ip /= scale2;
-		if (!nested())
-			nest2ring64(out->nside(), ip, &ip);
+		size_t ip = info_.RebinPixel(i.first, scale);
 		(*out)[ip] += i.second / sqscal;
 	}
 

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -284,7 +284,7 @@ HealpixSkyMap::ConvertToDense()
 	dense_ = new std::vector<double>(size(), 0);
 
 	if (ring_sparse_) {
-		long idx;
+		ssize_t idx;
 		for (auto i = ring_sparse_->begin(); i != ring_sparse_->end();
 		    i++) {
 			idx = info_.RingToPixel(i.x, i.y);
@@ -341,7 +341,7 @@ HealpixSkyMap::ConvertToIndexedSparse()
 	indexed_sparse_ = new std::unordered_map<uint64_t, double>;
 
 	if (ring_sparse_) {
-		long idx;
+		ssize_t idx;
 		for (auto i = ring_sparse_->begin(); i != ring_sparse_->end();
 		    i++) {
 			if ((*i) == 0)
@@ -996,7 +996,7 @@ size_t HealpixSkyMap::NpixNonZero() const
 	return sz;
 }
 
-size_t
+ssize_t
 HealpixSkyMap::AngleToPixel(double alpha, double delta) const
 {
 	return info_.AngleToPixel(alpha, delta);
@@ -1016,7 +1016,7 @@ void HealpixSkyMap::GetRebinAngles(size_t pixel, size_t scale,
 
 void
 HealpixSkyMap::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<size_t> & pixels, std::vector<double> & weights) const
+    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
 {
 	info_.GetInterpPixelsWeights(alpha, delta, pixels, weights);
 }
@@ -1053,7 +1053,7 @@ G3SkyMapPtr HealpixSkyMap::Rebin(size_t scale, bool norm) const
 	for (auto i : *this) {
 		if (i.second == 0)
 			continue;
-		size_t ip = i.first;
+		ssize_t ip = i.first;
 		if (!nested())
 			ring2nest64(nside(), ip, &ip);
 		ip /= scale2;
@@ -1148,7 +1148,7 @@ HealpixSkyMap_nonzeropixels(const HealpixSkyMap &m)
 }
 
 static double
-skymap_getitem(const G3SkyMap &skymap, int i)
+skymap_getitem(const G3SkyMap &skymap, ssize_t i)
 {
 
 	if (i < 0)
@@ -1162,7 +1162,7 @@ skymap_getitem(const G3SkyMap &skymap, int i)
 }
 
 static void
-skymap_setitem(G3SkyMap &skymap, int i, double val)
+skymap_setitem(G3SkyMap &skymap, ssize_t i, double val)
 {
 
 	if (i < 0)
@@ -1261,7 +1261,7 @@ static PyBufferProcs healpixskymap_bufferprocs;
 
 
 static void
-HealpixSkyMap_setitem_1d(G3SkyMap &skymap, size_t i, double val)
+HealpixSkyMap_setitem_1d(G3SkyMap &skymap, ssize_t i, double val)
 {
 
 	if (i < 0)

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -8,7 +8,6 @@
 
 #include <G3Units.h>
 #include <maps/HealpixSkyMap.h>
-#include "chealpix.h"
 #include <maps/G3SkyMapMask.h>
 
 #include "mapdata.h"
@@ -79,10 +78,10 @@ HealpixSkyMap::HealpixSkyMap(boost::python::object v, bool weighted,
 			PyBuffer_Release(&view);
 			log_fatal("Only 1-D maps supported");
 		}
+		ssize_t npix = view.shape[0];
 		PyBuffer_Release(&view);
 
-		nside = npix2nside(view.shape[0]);
-		info_.initialize(nside, nested, shift_ra);
+		info_.initialize(npix, nested, shift_ra, true);
 
 		FillFromArray(v);
 

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -284,7 +284,7 @@ HealpixSkyMap::ConvertToDense()
 	dense_ = new std::vector<double>(size(), 0);
 
 	if (ring_sparse_) {
-		ssize_t idx;
+		size_t idx;
 		for (auto i = ring_sparse_->begin(); i != ring_sparse_->end();
 		    i++) {
 			idx = info_.RingToPixel(i.x, i.y);
@@ -341,7 +341,7 @@ HealpixSkyMap::ConvertToIndexedSparse()
 	indexed_sparse_ = new std::unordered_map<uint64_t, double>;
 
 	if (ring_sparse_) {
-		ssize_t idx;
+		size_t idx;
 		for (auto i = ring_sparse_->begin(); i != ring_sparse_->end();
 		    i++) {
 			if ((*i) == 0)

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -6,7 +6,7 @@
 #include <G3Units.h>
 
 #include <maps/HealpixSkyMapInfo.h>
-#include <maps/chealpix.h>
+#include "chealpix.h"
 
 static const double twothird = 2.0 / 3.0;
 static const double twopi = 2 * M_PI;

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -258,6 +258,20 @@ HealpixSkyMapInfo::PixelToAngle(size_t pixel) const
 	return {alpha, delta};
 }
 
+size_t
+HealpixSkyMapInfo::RebinPixel(size_t pixel, size_t scale) const
+{
+	ssize_t pix = pixel;
+
+	if (!nested_)
+		ring2nest64(nside_, pix, &pix);
+	pix /= scale * scale;
+	if (!nested_)
+		nest2ring64(nside_ / scale, pix, &pix);
+
+	return pix;
+}
+
 void
 HealpixSkyMapInfo::GetRebinAngles(size_t pixel, size_t scale,
     std::vector<double> & alphas, std::vector<double> & deltas) const

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -27,9 +27,13 @@ HealpixSkyMapInfo::HealpixSkyMapInfo(const HealpixSkyMapInfo & other)
 }
 
 void
-HealpixSkyMapInfo::initialize(size_t nside, bool nested, bool shifted)
+HealpixSkyMapInfo::initialize(size_t nside_or_npix, bool nested, bool shifted,
+   bool is_npix)
 {
-	SetNSide(nside);
+	if (is_npix)
+		SetNPix(nside_or_npix);
+	else
+		SetNSide(nside_or_npix);
 	SetNested(nested);
 	SetShifted(shifted);
 }
@@ -84,6 +88,16 @@ double
 HealpixSkyMapInfo::res() const
 {
 	return sqrt(4.0 * M_PI / npix_) * G3Units::rad;
+}
+
+void
+HealpixSkyMapInfo::SetNPix(size_t npix)
+{
+	ssize_t nside = npix2nside64(npix);
+	if (nside < 0)
+		log_fatal("Invalid npix %zu", npix);
+
+	SetNSide(nside);
 }
 
 void

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -330,12 +330,12 @@ HealpixSkyMapInfo::RingAbove(double z) const
 
 void
 HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
-    std::vector<ssize_t> & pixels, std::vector<double> & weights) const
+    std::vector<size_t> & pixels, std::vector<double> & weights) const
 {
 	alpha /= G3Units::rad;
 	delta /= G3Units::rad;
 
-	pixels = std::vector<ssize_t>(4, -1);
+	pixels = std::vector<size_t>(4, (size_t) -1);
 	weights = std::vector<double>(4, 0);
 
 	double theta = M_PI_2 - delta;
@@ -414,17 +414,18 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 	}
 
 	if (nested_) {
-		ring2nest64(nside_, pixels[0], &pixels[0]);
-		ring2nest64(nside_, pixels[1], &pixels[1]);
-		ring2nest64(nside_, pixels[2], &pixels[2]);
-		ring2nest64(nside_, pixels[3], &pixels[3]);
+		for (size_t i = 0; i < pixels.size(); i++) {
+			ssize_t pix = pixels[i];
+			ring2nest64(nside_, pix, &pix);
+			pixels[i] = pix;
+		}
 	}
 }
 
-std::vector<ssize_t>
+std::vector<size_t>
 HealpixSkyMapInfo::QueryDisc(double alpha, double delta, double radius) const
 {
-	auto pixels = std::vector<ssize_t>();
+	auto pixels = std::vector<size_t>();
 
 	radius /= G3Units::rad;
 	if (radius >= M_PI) {
@@ -499,8 +500,11 @@ HealpixSkyMapInfo::QueryDisc(double alpha, double delta, double radius) const
 	}
 
 	if (nested_) {
-		for (size_t i = 0; i < pixels.size(); i++)
-			ring2nest64(nside_, pixels[i], &pixels[i]);
+		for (size_t i = 0; i < pixels.size(); i++) {
+			ssize_t pix = pixels[i];
+			ring2nest64(nside_, pix, &pix);
+			pixels[i] = pix;
+		}
 		std::sort(pixels.begin(), pixels.end());
 	}
 

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -173,7 +173,7 @@ HealpixSkyMapInfo::PixelToRing(size_t pixel) const
 
 	const HealpixRingInfo & ring = rings_[iring];
 
-	ssize_t ringpix = pixel - ring.pix0;
+	size_t ringpix = pixel - ring.pix0;
 	if (ringpix >= ring.npix)
 		return bad;
 
@@ -208,7 +208,7 @@ HealpixSkyMapInfo::RingToPixel(size_t iring, size_t ringpix) const
 	return pixel;
 }
 
-ssize_t
+size_t
 HealpixSkyMapInfo::AngleToPixel(double alpha, double delta) const
 {
 	if (std::isnan(alpha) || std::isnan(delta))
@@ -290,13 +290,13 @@ HealpixSkyMapInfo::GetRebinAngles(size_t pixel, size_t scale,
 	}
 }
 
-ssize_t
+size_t
 HealpixSkyMapInfo::RingAbove(double z) const
 {
 	double za = fabs(z);
 	if (za <= twothird)
 		return nside_ * (2 - 1.5 * z);
-	ssize_t iring = nside_ * sqrt(3 * (1 - za));
+	size_t iring = nside_ * sqrt(3 * (1 - za));
 	return (z > 0) ? iring : (nring_ - iring - 1);
 }
 
@@ -316,8 +316,8 @@ HealpixSkyMapInfo::GetInterpPixelsWeights(double alpha, double delta,
 
 	double phi = (alpha < 0) ? (alpha + twopi) : alpha;
 
-	ssize_t ir1 = RingAbove(z);
-	ssize_t ir2 = ir1 + 1;
+	size_t ir1 = RingAbove(z);
+	size_t ir2 = ir1 + 1;
 
 	double z1, z2;
 
@@ -417,7 +417,7 @@ HealpixSkyMapInfo::QueryDisc(double alpha, double delta, double radius) const
 
 	double rlat1 = theta - radius;
 	double zmax = cos(rlat1);
-	ssize_t irmin = RingAbove(zmax) + 1;
+	size_t irmin = RingAbove(zmax) + 1;
 
 	if ((rlat1 <= 0) && (irmin > 1)) {
 		// north pole in the disk
@@ -428,7 +428,7 @@ HealpixSkyMapInfo::QueryDisc(double alpha, double delta, double radius) const
 
 	double rlat2 = theta + radius;
 	double zmin = cos(rlat2);
-	ssize_t irmax = RingAbove(zmin);
+	size_t irmax = RingAbove(zmin);
 
 	for (size_t iring = irmin; iring <= irmax; iring++) {
 		const HealpixRingInfo & ring = rings_[iring];

--- a/maps/src/MapMockObserver.cxx
+++ b/maps/src/MapMockObserver.cxx
@@ -215,7 +215,7 @@ MapMockObserver::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 			    pcoupling, U_->GetPolConv());
 			for (size_t i = 0; i < det.size(); i++) {
 				if (interp_) {
-					std::vector<ssize_t> pixels;
+					std::vector<size_t> pixels;
 					std::vector<double> weights;
 					T_->GetInterpPixelsWeights(alpha[i], delta[i], pixels, weights);
 					det[i] =

--- a/maps/src/MapMockObserver.cxx
+++ b/maps/src/MapMockObserver.cxx
@@ -205,7 +205,7 @@ MapMockObserver::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 		std::vector<double> alpha, delta;
 		get_detector_pointing(bp.x_offset, bp.y_offset, *pointing,
 		    T_->coord_ref, alpha, delta);
-		std::vector<ssize_t> detpointing;
+		std::vector<size_t> detpointing;
 		if (!interp_)
 			detpointing = T_->AnglesToPixels(alpha, delta);
 

--- a/maps/src/MapMockObserver.cxx
+++ b/maps/src/MapMockObserver.cxx
@@ -205,7 +205,7 @@ MapMockObserver::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 		std::vector<double> alpha, delta;
 		get_detector_pointing(bp.x_offset, bp.y_offset, *pointing,
 		    T_->coord_ref, alpha, delta);
-		std::vector<size_t> detpointing;
+		std::vector<ssize_t> detpointing;
 		if (!interp_)
 			detpointing = T_->AnglesToPixels(alpha, delta);
 
@@ -215,7 +215,7 @@ MapMockObserver::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 			    pcoupling, U_->GetPolConv());
 			for (size_t i = 0; i < det.size(); i++) {
 				if (interp_) {
-					std::vector<long> pixels;
+					std::vector<ssize_t> pixels;
 					std::vector<double> weights;
 					T_->GetInterpPixelsWeights(alpha[i], delta[i], pixels, weights);
 					det[i] =

--- a/maps/src/SingleDetectorBoresightBinner.cxx
+++ b/maps/src/SingleDetectorBoresightBinner.cxx
@@ -184,7 +184,7 @@ SingleDetectorBoresightBinner::Process(G3FramePtr frame,
 	
 	// Conjugate pointing rotation with boresight vector
 	auto pointing_vec = (*pointing)*quat(0,1,0,0)/(*pointing);
-	std::vector<size_t> pixels = template_->QuatsToPixels(pointing_vec);
+	auto pixels = template_->QuatsToPixels(pointing_vec);
 
 	for (size_t i = 0; i < pixels.size(); i++)
 		(*map_weights_->TT)[pixels[i]] += 1;

--- a/maps/src/chealpix.c
+++ b/maps/src/chealpix.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <maps/chealpix.h>
+#include "chealpix.h"
 
 static const double twothird=2.0/3.0;
 static const double pi=3.141592653589793238462643383279502884197;

--- a/maps/src/chealpix.h
+++ b/maps/src/chealpix.h
@@ -106,7 +106,7 @@ void pix2vec_ring(long nside, long ipix, double *vec);
 /* operations on Nside values up to 2^29 */
 
 /*! 64bit integer type
-    \note We use int64_t here because it is now part of the C++ standard. */
+    \note We use ssize_t here since this is properly defined on all platforms. */
 typedef ssize_t hpint64;
 
 /*! Sets \a *ipix to the pixel number in NEST scheme at resolution \a nside,

--- a/maps/src/chealpix.h
+++ b/maps/src/chealpix.h
@@ -107,7 +107,7 @@ void pix2vec_ring(long nside, long ipix, double *vec);
 
 /*! 64bit integer type
     \note We use int64_t here because it is now part of the C++ standard. */
-typedef int64_t hpint64;
+typedef ssize_t hpint64;
 
 /*! Sets \a *ipix to the pixel number in NEST scheme at resolution \a nside,
     which contains the position \a theta, \a phi. */

--- a/maps/src/chealpix.h
+++ b/maps/src/chealpix.h
@@ -106,9 +106,8 @@ void pix2vec_ring(long nside, long ipix, double *vec);
 /* operations on Nside values up to 2^29 */
 
 /*! 64bit integer type
-    \note We are not using \c int64_t, since this type is not part of the C++
-    standard, and we want the header to be usable from C++. */
-typedef long long hpint64;
+    \note We use int64_t here because it is now part of the C++ standard. */
+typedef int64_t hpint64;
 
 /*! Sets \a *ipix to the pixel number in NEST scheme at resolution \a nside,
     which contains the position \a theta, \a phi. */

--- a/maps/tests/healpix_maps.py
+++ b/maps/tests/healpix_maps.py
@@ -221,3 +221,9 @@ maps.reproj_map(x, xeq)
 lon, lat = maps.azel.convert_radec_to_gal(alpha, delta)
 pix = xeq.angles_to_pixels(lon, lat)
 assert(np.allclose(np.asarray(pix), np.asarray(xeq)))
+
+# high-res
+hx = maps.HealpixSkyMap(16384)
+pix1 = hx.angle_to_pixel(0, -45 * core.G3Units.deg)
+pix2 = hp.ang2pix(16384, 3 * np.pi / 4, 0)
+assert(pix1 == pix2)


### PR DESCRIPTION
This PR ensures that maps are consistently indexed using 64-bit integers everywhere, to avoid truncation e.g. when indexing maps with high nside (>8192).  The healpix C bindings are moved out of the public API, and the header is modified to use the `ssize_t` integer type for all 64-bit functions.

Fixes #119