### PR TITLE
Add G3MapQuat and G3MapVectorQuat objects

### DIFF
--- a/core/include/core/G3Map.h
+++ b/core/include/core/G3Map.h
@@ -3,6 +3,7 @@
 
 #include <G3Frame.h>
 #include <G3Vector.h>
+#include <G3Quat.h>
 #include <map>
 #include <sstream>
 #include <complex>
@@ -78,6 +79,8 @@ G3MAP_OF(std::string, std::vector<std::complex<double> >, G3MapVectorComplexDoub
 G3MAP_OF(std::string, G3VectorTime, G3MapVectorTime);
 G3MAP_OF(std::string, int32_t, G3MapInt);
 G3MAP_OF(std::string, std::string, G3MapString);
+G3MAP_OF(std::string, quat, G3MapQuat);
+G3MAP_OF(std::string, G3VectorQuat, G3MapVectorQuat);
 
 namespace cereal {
         template <class A> struct specialize<A, G3MapFrameObject, cereal::specialization::member_load_save> {};

--- a/core/src/G3Map.cxx
+++ b/core/src/G3Map.cxx
@@ -74,6 +74,7 @@ G3_SERIALIZABLE_CODE(G3MapInt);
 G3_SERIALIZABLE_CODE(G3MapDouble);
 G3_SERIALIZABLE_CODE(G3MapMapDouble);
 G3_SERIALIZABLE_CODE(G3MapString);
+G3_SERIALIZABLE_CODE(G3MapQuat);
 G3_SERIALIZABLE_CODE(G3MapVectorBool);
 G3_SERIALIZABLE_CODE(G3MapVectorInt);
 G3_SERIALIZABLE_CODE(G3MapVectorDouble);
@@ -81,6 +82,7 @@ G3_SERIALIZABLE_CODE(G3MapVectorString);
 G3_SERIALIZABLE_CODE(G3MapVectorVectorString);
 G3_SERIALIZABLE_CODE(G3MapVectorComplexDouble);
 G3_SERIALIZABLE_CODE(G3MapVectorTime);
+G3_SERIALIZABLE_CODE(G3MapVectorQuat);
 
 G3_SPLIT_SERIALIZABLE_CODE(G3MapFrameObject);
 
@@ -95,6 +97,8 @@ PYBINDINGS("core") {
 	register_g3map<G3MapInt>("G3MapInt", "Mapping from strings to ints.");
 	register_g3map<G3MapString>("G3MapString", "Mapping from strings to "
 	    "strings.");
+	register_g3map<G3MapQuat>("G3MapQuat", "Mapping from strings to "
+	    "quaternions.");
 	register_g3map<G3MapVectorBool>("G3MapVectorBool", "Mapping from "
 	    "strings to arrays of booleans.");
 	register_g3map<G3MapVectorDouble>("G3MapVectorDouble", "Mapping from "
@@ -109,6 +113,8 @@ PYBINDINGS("core") {
 	    "Mapping from strings to lists of lists of strings.");
 	register_g3map<G3MapVectorTime>("G3MapVectorTime", "Mapping from "
 	    "strings to lists of G3 time objects.");
+	register_g3map<G3MapVectorQuat>("G3MapVectorQuat", "Mapping from "
+	    "strings to lists of quaternions.");
 
 	// Special handling to get the object proxying right
 	register_g3map<G3MapFrameObject, true>("G3MapFrameObject", "Mapping "

--- a/core/src/G3Quat.cxx
+++ b/core/src/G3Quat.cxx
@@ -606,7 +606,7 @@ PYBINDINGS("core")
 	     .def("dot3", dot3, "Dot product of last three entries")
 	     .def("cross3", cross3, "Cross product of last three entries")
 	;
-	register_vector_of<quat>("QuatVector");
+	register_vector_of<quat>("Quat");
 	object vq =
 	    register_g3vector<quat>("G3VectorQuat",
 	     "List of quaternions. Convertible to a 4xN numpy array. "


### PR DESCRIPTION
These are useful for storing per-bolometer offset quaternions, for example.