### PR TITLE
Implement custom loading of pybindings to replace `imp.load_dynamic`

### DIFF
--- a/calibration/src/python.cxx
+++ b/calibration/src/python.cxx
@@ -2,7 +2,7 @@
 
 namespace bp = boost::python;
 
-BOOST_PYTHON_MODULE(calibration)
+SPT3G_PYTHON_MODULE(calibration)
 {
 	// Python bindings dependencies
 	bp::import("spt3g.core");

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,14 @@
+# Build a minimal library with a constant name which can be loaded as a python
+# module with a plain `import`, which can then load other modules which are
+# native libraries with normal names.
+add_library(dload SHARED src/dload.c)
+set_target_properties(dload PROPERTIES PREFIX "")
+set_target_properties(dload PROPERTIES SUFFIX ".so")
+install(TARGETS dload DESTINATION ${PYTHON_MODULE_DIR}/spt3g)
+MESSAGE("Setting dload target_include_directories to ${Python_INCLUDE_DIRS}")
+target_include_directories(dload PRIVATE ${Python_INCLUDE_DIRS})
+target_link_libraries(dload PUBLIC ${Python_LIBRARIES})
+
 # OS X has a broken implementatin of pthreads.
 if(APPLE)
 	set(CORE_EXTRA_SRCS src/ApplePthreadBarrier.cxx)

--- a/core/python/load_pybindings.py
+++ b/core/python/load_pybindings.py
@@ -18,13 +18,13 @@ else:
     lib_suffix = ".so"
 
 def load_pybindings(name, path):
-	import imp, os, sys
+	import os
 	mod = sys.modules[name]
 	p = os.path.split(path[0])
-	m = imp.load_dynamic(name, p[0] + "/" + lib_prefix + p[1] + lib_suffix)
+	from spt3g import dload
+	m = dload.load_dynamic(name, p[1], p[0] + "/" + lib_prefix + p[1] + lib_suffix)
 	sys.modules[name] = mod # Don't override Python mod with C++
 
 	for (k,v) in m.__dict__.items():
 		if not k.startswith("_"):
 			mod.__dict__[k] = v
-

--- a/core/src/dload.c
+++ b/core/src/dload.c
@@ -1,0 +1,122 @@
+#include <dlfcn.h>
+
+#include <Python.h>
+
+static PyObject* load_dynamic_library(PyObject* mod, PyObject* args, PyObject* kwds){
+	static const char* kwlist[] = {"full_name", "name", "path", NULL};
+	char* full_name=NULL;
+	char* name=NULL;
+	char* path=NULL;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "sss", (char**)kwlist, &full_name, &name, &path))
+		return Py_None;
+	
+	void* h = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+    char* errmsg = dlerror();
+    
+    if(h == NULL || errmsg != NULL){
+    	char err_buf[1024];
+    	snprintf(err_buf, 1024, "dynamic loading error: loading '%s' from '%s': %s", name, path, 
+    	         (errmsg == NULL ? "dlopen: unknown error" : errmsg));
+    	PyErr_SetString(PyExc_RuntimeError, err_buf);
+		return Py_None;
+    }
+    PyObject* (*init)(void);
+    char initName[256];
+    int print_res = 0;
+#if PY_MAJOR_VERSION >= 3
+	print_res = snprintf(initName, 256, "PyInit_%s", name);
+#else
+	print_res = snprintf(initName, 256, "init%s", name);
+#endif
+	if(print_res<0){
+		char err_buf[1024];
+    	snprintf(err_buf, 1024, "dynamic loading error: loading '%s' from '%s': "
+    	         "module init function name too long", name, path);
+    	PyErr_SetString(PyExc_RuntimeError, err_buf);
+		return Py_None;
+	}
+
+    *(void **) (&init) = dlsym(h,initName);
+    errmsg = dlerror();
+    if(errmsg != NULL){
+    	char err_buf[1024];
+    	snprintf(err_buf, 1024, "dynamic loading error: loading '%s' from '%s': %s", name, path,
+    	         (errmsg == NULL ? "dlsym: unknown error" : errmsg));
+    	printf("%s\n", err_buf);
+    	PyErr_SetString(PyExc_RuntimeError, err_buf);
+		return Py_None;
+    }
+    
+#if PY_MAJOR_VERSION >= 3
+    PyObject* module = (*init)();
+    PyObject_SetAttrString(module, "__file__", PyUnicode_FromString(path));
+#else
+	(*init)();
+	PyObject* module = PyDict_GetItemString(PyImport_GetModuleDict(), full_name);
+	if(nmod==NULL){
+		char err_buf[1024];
+		snprintf(err_buf, 1024, "dynamic loading error: %s not in global module dict", full_name);
+		PyErr_SetString(PyExc_RuntimeError, err_buf);
+		return Py_None;
+	}
+	PyObject_SetAttrString(module, "__file__", PyString_FromString(path));
+#endif
+	return module;
+}
+
+static PyMethodDef spt3g_dload_methods[] = {
+	{"load_dynamic", (PyCFunction)&load_dynamic_library, METH_VARARGS | METH_KEYWORDS, 
+	 "\n"
+	 "Load a compiled extension module. No restriction is placed on the relationship\n"
+	 "between the name of the module and the name of the dynamic library file which\n"
+	 "implements it; e.g. module `foo` need not reside in `foo.so`.\n"
+	 "\n"
+	 "Arguments\n"
+	 "---------\n"
+	 "full_name : str\n"
+	 "    The module's fully qualified name\n"
+	 "name : str\n"
+	 "    The module's name\n"
+	 "path : str\n"
+	 "    The path to the dynamic library which implements the module\n"
+	 "\n"
+	 "Returns\n"
+	 "-------\n"
+	 "The loaded module\n"
+	},
+	{NULL, NULL, 0, NULL}
+};
+
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+	PyModuleDef_HEAD_INIT,
+	"spt3g_dload",
+	"A beach-head module for loading other compiled spt3g modules",
+	0,
+	spt3g_dload_methods,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+};
+#endif
+
+PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+PyInit_dload(void){
+#else
+initdload(void){
+#endif
+	PyObject* module;
+	
+#if PY_MAJOR_VERSION >= 3
+	module = PyModule_Create(&moduledef);
+	PyObject_SetAttrString(module, "__version__", PyUnicode_FromString("1.0.0"));
+	return module;
+#else
+	module = Py_InitModule3("spt3g_dload", spt3g_dload_methods,
+	                        "A beach-head module for loading other compiled spt3g modules");
+	PyObject_SetAttrString(module, "__version__", PyString_FromString("1.0.0"));
+	PyDict_SetItemString(PyImport_GetModuleDict(),_Py_PackageContext,module);
+#endif
+}

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -368,7 +368,7 @@ numpy_container_from_object(boost::python::object v)
 numpy_vector_infrastructure(std::complex<double>, cxdouble, "Zd");
 numpy_vector_infrastructure(std::complex<float>, cxfloat, "Zf");
 
-BOOST_PYTHON_MODULE(core)
+SPT3G_PYTHON_MODULE(core)
 {
 	bp::docstring_options docopts(true, true, false);
 

--- a/dfmux/src/python.cxx
+++ b/dfmux/src/python.cxx
@@ -2,7 +2,7 @@
 
 namespace bp = boost::python;
 
-BOOST_PYTHON_MODULE(dfmux)
+SPT3G_PYTHON_MODULE(dfmux)
 {
 	// Python bindings dependencies
 	bp::import("spt3g.core");

--- a/doc/buildsystem.rst
+++ b/doc/buildsystem.rst
@@ -60,7 +60,7 @@ Every C++ library must contain a file declaring the library to Python. This file
 	#include <pybindings.h>
 	#include <boost/python.hpp>
 
-	BOOST_PYTHON_MODULE(newthing)
+	SPT3G_PYTHON_MODULE(newthing)
 	{
 		boost::python::import("spt3g.core"); // Import core python bindings
 

--- a/gcp/src/python.cxx
+++ b/gcp/src/python.cxx
@@ -7,7 +7,7 @@
 
 namespace bp = boost::python;
 
-BOOST_PYTHON_MODULE(gcp)
+SPT3G_PYTHON_MODULE(gcp)
 {
 	bp::import("spt3g.core");
 	bp::docstring_options docopts(true, true, false);

--- a/maps/src/python.cxx
+++ b/maps/src/python.cxx
@@ -2,7 +2,7 @@
 
 namespace bp = boost::python;
 
-BOOST_PYTHON_MODULE(maps)
+SPT3G_PYTHON_MODULE(maps)
 {
 	bp::import("spt3g.core");
 	bp::docstring_options docopts(true, true, false);


### PR DESCRIPTION
Write our own dynamic loading and module initialization code which does not depend on the `imp` module. This breaks the dilemma between the `imp` module being removed in python 3.12 and not being able to load the python bindings via the standard `import` mechanism because the library names do not conform to python's non-standard expectations. 

An `SPT3G_PYTHON_MODULE` macro is introduced to wrap `BOOST_PYTHON_MODULE`. This is needed to work around [an awkward detail of how python modules are initialized](https://github.com/python/cpython/blob/3.12/Python/import.c#L701-L706):

>   This is a bit of a hack: when the shared library is loaded,
>   the module name is "package.module", but the module calls
>   PyModule_Create*() with just "module" for the name.  The shared
>   library loader squirrels away the true name of the module in
>   _PyRuntime.imports.pkgcontext, and PyModule_Create*() will
>   substitute this (if the name actually matches).

This causes problems because each class created within a module takes the module object's name to form its own fully-qualified name, so for those to be correct, we need to patch the modules `__name__` after it is created (by `PyModule_Create`/`Py_InitModule`), but before any of its own initialization code starts running. The new wrapper macro allows us to insert the fix-up code which does this. (It would be elegant to use the same interface that python uses internally to have `PyModule_Create`/`Py_InitModule` just do the right thing for us, but that interface is private and has not been stable across versions.)

This has been tested on python 2.7, 3.7, 3.8, and 3.12. 
There is one test failure on python 3.12, however, it appears to be unrelated:

	39/48 Test #39: maps/transtest .............................***Failed    1.76 sec
	Traceback (most recent call last):
	  File "/Users/christopher/Work/CMB-S4/spt3g_software-public-git/maps/tests/transtest.py", line 32, in <module>
	    g = c.transform_to(astropy.coordinates.Galactic)
	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/Users/christopher/.local/lib/python3.12/site-packages/astropy/coordinates/baseframe.py", line 1272, in transform_to
	    raise ConvertError(msg.format(self.__class__, new_frame.__class__))
	astropy.coordinates.errors.ConvertError: Cannot transform from <class 'astropy.coordinates.builtin_frames.fk5.FK5'> to <class 'abc.ABCMeta'>

as the problem can be reproduced by a reduced test-case which does not involve spt3g_software, suggesting that the cause is an `astropy` bug:

	import numpy as np
	import astropy.coordinates
	from astropy import units as u

	np.random.seed(42)
	n_samps = int(1e3)

	ra_0 = np.random.rand(n_samps)*2.0*np.pi - np.pi
	pole_avoidance = 0.7
	dec_0 = np.random.rand(n_samps)*np.pi*pole_avoidance-np.pi/2.0*pole_avoidance

	c = astropy.coordinates.FK5(ra=np.asarray(ra_0)*u.rad, dec=np.asarray(dec_0)*u.rad)
	g = c.transform_to(astropy.coordinates.Galactic)

There are also various test failures on python 2.7, but they appear to involve various cases of invalid (too-new) syntax in existing scripts, but other scripts without those issues work, and most tests pass. 

Addresses https://github.com/CMB-S4/spt3g_software/issues/127