### PR TITLE
Smarter handling of map polarization properties

### DIFF
--- a/maps/README.rst
+++ b/maps/README.rst
@@ -27,7 +27,7 @@ The following attributes are common to all G3SkyMap subclasses:
   The Stokes polarization of the map object, which is an instance of the ``MapPolType`` enum, and can have the value ``T``, ``Q``, ``U`` or None.
 
 ``pol_conv``
-  The polarization convention used to encode the Q and U Stokes orientations relative to the coordinate axes.  This attribute is an instance of the ``MapPolConv`` enum, which can have the value ``IAU``, ``COSMO`` or None.  Both IAU and COSMO polarization conventions are supported in polarization-aware functions (e.g. ``FlattenPol``), but most default to using the IAU convention.  Warnings will be raised when a polarized map is used without a polarization convention set.  Changing the polarization convention between IAU and COSMO on a ``U`` map results in flipping the sign of all pixels in the map.
+  The polarization convention used to encode the Q and U Stokes orientations relative to the coordinate axes.  This attribute is an instance of the ``MapPolConv`` enum, which can have the value ``IAU``, ``COSMO`` or None.  Both IAU and COSMO polarization conventions are supported in polarization-aware functions (e.g. ``FlattenPol``), but most default to using the IAU convention.  Warnings will be raised when a polarized map is used without a polarization convention set.  Use the ``SetPolConv`` pipeline module to change the polarization convention between IAU and COSMO for an entire map frame.  This will result in flipping the sign of all pixels in the ``U`` map as well as the ``TU`` and ``QU`` weights.
   
 ``units``
   The units system in which the map is computed, stored as an instance of the ``G3TimestreamUnits`` enum, typically ``Tcmb``.

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -33,7 +33,18 @@ public:
 		U = 2,
 		E = 3,
 		B = 4,
-		None = 7
+		None = 7,
+		TT = 8,
+		TQ = 9,
+		TU = 10,
+		QQ = 11,
+		QU = 12,
+		UU = 13,
+		TE = 14,
+		TB = 15,
+		EE = 16,
+		EB = 17,
+		BB = 18,
 	};
 
 	enum MapPolConv {
@@ -77,6 +88,8 @@ public:
 
 	MapPolConv GetPolConv() const { return pol_conv_; };
 	void SetPolConv(MapPolConv pol_conv);
+
+	bool IsPolarized() const { return pol_conv_ != ConvNone; }
 
 	virtual bool IsCompatible(const G3SkyMap & other) const {
 		if (shape().size() != other.shape().size())
@@ -378,7 +391,7 @@ public:
 	G3SkyMapWeights() {}
 
 	// Instantiate weight maps based on the metadata of a reference map
-	G3SkyMapWeights(G3SkyMapConstPtr ref_map, bool polarized = true);
+	G3SkyMapWeights(G3SkyMapConstPtr ref_map);
 
 	G3SkyMapWeights(const G3SkyMapWeights &r, bool copy_data = true);
 	G3SkyMapPtr TT, TQ, TU, QQ, QU, UU;

--- a/maps/include/maps/G3SkyMap.h
+++ b/maps/include/maps/G3SkyMap.h
@@ -66,6 +66,7 @@ public:
 	MapCoordReference coord_ref;
 	G3Timestream::TimestreamUnits units;
 	MapPolType pol_type;
+	MapPolConv pol_conv;
 	bool weighted;
 	double overflow;
 
@@ -86,10 +87,7 @@ public:
 	virtual size_t NpixNonZero(void) const = 0;  // nonzero
 	virtual std::vector<size_t> shape(void) const = 0;  // map shape
 
-	MapPolConv GetPolConv() const { return pol_conv_; };
-	void SetPolConv(MapPolConv pol_conv);
-
-	bool IsPolarized() const { return pol_conv_ != ConvNone; }
+	bool IsPolarized() const { return pol_conv != ConvNone; }
 
 	virtual bool IsCompatible(const G3SkyMap & other) const {
 		if (shape().size() != other.shape().size())
@@ -218,8 +216,6 @@ public:
 	    bool zero_infs = false) const;
 
 protected:
-	MapPolConv pol_conv_;
-
 	virtual void InitFromV1Data(std::vector<size_t>,
 	    const std::vector<double> &) {
 		throw std::runtime_error("Initializing from V1 not implemented");

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -204,6 +204,7 @@ def MakeMapsPolarized(frame, pol_conv=maps.MapPolConv.IAU):
         return
 
     wgt = frame["Wunpol"].TT
+    wgt.pol_conv = pol_conv
     del frame["Wunpol"]
 
     qmap = frame["T"].clone(False)
@@ -215,8 +216,6 @@ def MakeMapsPolarized(frame, pol_conv=maps.MapPolConv.IAU):
     umap.pol_conv = pol_conv
     frame["U"] = umap
     mask = wgt.to_mask().to_map()
-    mask.units = qmap.units
-    mask.weighted = qmap.weighted
 
     wgt_out = maps.G3SkyMapWeights()
     wgt_out.TT = wgt
@@ -228,7 +227,6 @@ def MakeMapsPolarized(frame, pol_conv=maps.MapPolConv.IAU):
 
     for k in wgt_out.keys():
         wgt_out[k].pol_type = getattr(maps.MapPolType, k)
-        wgt_out[k].pol_conv = pol_conv
 
     frame["Wpol"] = wgt_out
 

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -297,6 +297,17 @@ def ValidateMaps(frame, ignore_missing_weights=False):
                 unit="ValidateMaps",
             )
 
+        if k in ["Wpol", "Wunpol"]:
+            if frame[k].TT.pol_type == maps.MapPolType.TT:
+                continue
+            # set weights polarization properties
+            w = frame.pop(k)
+            for wk in w.keys():
+                w[wk].pol_type = getattr(maps.MapPolType, wk)
+                if k == "Wpol":
+                    w[wk].pol_conv = frame["U"].pol_conv
+            frame[k] = w
+
         if k in "TQU":
             if k == "U":
                 if isinstance(frame[k], maps.FlatSkyMap) and (
@@ -876,8 +887,8 @@ class ReprojectMaps(object):
                 "Coordinate rotation of polarized maps is not implemented"
             )
 
-        if "Q" in frame and not self.stub.polarized:
-            self.stub.pol_conv = frame["Q"].pol_conv
+        if "U" in frame and not self.stub.polarized:
+            self.stub.pol_conv = frame["U"].pol_conv
 
         for key in ["T", "Q", "U", "Wpol", "Wunpol", "H"]:
 

--- a/maps/python/skymapaddons.py
+++ b/maps/python/skymapaddons.py
@@ -177,6 +177,8 @@ del skymapweights_reshape
 def skymapweights_getattr(self, x):
     if x == "flat_pol" and isinstance(self.TQ, FlatSkyMap):
         return getattr(self.TQ, x)
+    if x == "pol_conv" and isinstance(self.TU, FlatSkyMap):
+        return getattr(self.TU, x)
     if hasattr(self.TT, x):
         return getattr(self.TT, x)
     raise AttributeError("'{}' object has no attribute '{}'".format(type(self), x))

--- a/maps/src/FlatSkyMap.cxx
+++ b/maps/src/FlatSkyMap.cxx
@@ -349,7 +349,7 @@ FlatSkyMap::Clone(bool copy_data) const
 		return boost::make_shared<FlatSkyMap>(*this);
 	else
 		return boost::make_shared<FlatSkyMap>(proj_info,
-		    coord_ref, weighted, units, pol_type, flat_pol_, pol_conv_);
+		    coord_ref, weighted, units, pol_type, flat_pol_, pol_conv);
 }
 
 double
@@ -567,7 +567,7 @@ FlatSkyMap::Description() const
 	default:
 		os << "unknown";
 	}
-	switch (pol_conv_) {
+	switch (pol_conv) {
 	case IAU:
 		os << " IAU";
 		break;
@@ -793,7 +793,7 @@ G3SkyMapPtr FlatSkyMap::Rebin(size_t scale, bool norm) const
 
 	FlatSkyProjection p(proj_info.Rebin(scale));
 	FlatSkyMapPtr out(new FlatSkyMap(p, coord_ref, weighted, units, pol_type,
-	    flat_pol_, pol_conv_));
+	    flat_pol_, pol_conv));
 
 	if (dense_)
 		out->ConvertToDense();
@@ -821,7 +821,7 @@ G3SkyMapPtr FlatSkyMap::ExtractPatch(size_t x0, size_t y0, size_t width, size_t 
 
 	FlatSkyProjection p(proj_info.OverlayPatch(x0, y0, width, height));
 	FlatSkyMapPtr out(new FlatSkyMap(p, coord_ref, weighted, units, pol_type,
-	    flat_pol_, pol_conv_));
+	    flat_pol_, pol_conv));
 
 	if (fill != 0 && (width > xpix_ || height > ypix_))
 		(*out) += fill;

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -48,9 +48,9 @@ G3SkyMap::serialize(A &ar, unsigned v)
 	ar & cereal::make_nvp("weighted", weighted);
 
 	if (v > 2) {
-		ar & cereal::make_nvp("pol_conv", pol_conv_);
+		ar & cereal::make_nvp("pol_conv", pol_conv);
 	} else {
-		pol_conv_ = ConvNone;
+		pol_conv = ConvNone;
 	}
 
 }
@@ -109,9 +109,9 @@ G3SkyMap::G3SkyMap(MapCoordReference coords, bool weighted,
     G3Timestream::TimestreamUnits units, MapPolType pol_type,
     MapPolConv pol_conv) :
     coord_ref(coords), units(units), pol_type(pol_type),
-    weighted(weighted), overflow(0), pol_conv_(pol_conv)
+    pol_conv(pol_conv), weighted(weighted), overflow(0)
 {
-	if (isumap(*this) && pol_conv_ == ConvNone)
+	if (isumap(*this) && pol_conv == ConvNone)
 		log_warn("Map object has pol_type U and unknown pol_conv. "
 			 "Set the pol_conv attribute to IAU or COSMO.");
 }
@@ -491,30 +491,6 @@ skymap_setitem(G3SkyMap &skymap, ssize_t i, double val)
 	}
 
 	skymap[i] = val;
-}
-
-void
-G3SkyMap::SetPolConv(G3SkyMap::MapPolConv pol_conv)
-{
-	if (isumap(*this) && pol_conv == G3SkyMap::ConvNone)
-		log_warn("Map object has pol_type U and unknown pol_conv. "
-			 "Set the pol_conv attribute to IAU or COSMO.");
-
-	if (!isumap(*this) ||
-	    pol_conv == G3SkyMap::ConvNone ||
-	    pol_conv_ == G3SkyMap::ConvNone) {
-		pol_conv_ = pol_conv;
-		return;
-	}
-
-	if (pol_conv != pol_conv_) {
-		log_warn("Sign of U map flipped in changing pol_conv from %s to %s",
-		    pol_conv == G3SkyMap::IAU ? "COSMO" : "IAU",
-		    pol_conv == G3SkyMap::IAU ? "IAU" : "COSMO");
-		(*this) *= -1;
-        }
-
-	pol_conv_ = pol_conv;
 }
 
 static bp::tuple
@@ -1474,11 +1450,9 @@ PYBINDINGS("maps") {
 	    .def_readwrite("pol_type", &G3SkyMap::pol_type,
 	      "Polarization type (maps.MapPolType) of the map "
 	      "(e.g. maps.MapPolType.Q).")
-	    .add_property("pol_conv", &G3SkyMap::GetPolConv, &G3SkyMap::SetPolConv,
+	    .def_readwrite("pol_conv", &G3SkyMap::pol_conv,
 	      "Polarization convention (maps.MapPolConv) of the map "
-	      "(e.g. maps.MapPolConv.IAU or maps.MapPolConv.COSMO). "
-	      "Switching between IAU and COSMO conventions for a U map "
-	      "multiplies the U map by -1.")
+	      "(e.g. maps.MapPolConv.IAU or maps.MapPolConv.COSMO).")
 	    .add_property("polarized", &G3SkyMap::IsPolarized,
 	      "True if the pol_conv property is set to IAU or COSMO, False otherwise.")
 	    .def_readwrite("units", &G3SkyMap::units,

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -90,13 +90,28 @@ G3SkyMapWeights::serialize(A &ar, unsigned v)
 G3_SERIALIZABLE_CODE(G3SkyMap);
 G3_SERIALIZABLE_CODE(G3SkyMapWeights);
 
+
+static bool
+isumap(const G3SkyMap &m)
+{
+  if (m.pol_type == G3SkyMap::U)
+    return true;
+  if (m.pol_type == G3SkyMap::TU)
+    return true;
+  if (m.pol_type == G3SkyMap::QU)
+    return true;
+
+  return false;
+}
+
+
 G3SkyMap::G3SkyMap(MapCoordReference coords, bool weighted,
     G3Timestream::TimestreamUnits units, MapPolType pol_type,
     MapPolConv pol_conv) :
     coord_ref(coords), units(units), pol_type(pol_type),
     weighted(weighted), overflow(0), pol_conv_(pol_conv)
 {
-	if (pol_type == U && pol_conv == ConvNone)
+	if (isumap(*this) && pol_conv_ == ConvNone)
 		log_warn("Map object has pol_type U and unknown pol_conv. "
 			 "Set the pol_conv attribute to IAU or COSMO.");
 }
@@ -111,20 +126,20 @@ G3SkyMap::ArrayClone(boost::python::object val) const
 }
 
 
-G3SkyMapWeights::G3SkyMapWeights(G3SkyMapConstPtr ref, bool polarized) :
-    TT(ref->Clone(false)), TQ(polarized ? ref->Clone(false) : NULL),
-    TU(polarized ? ref->Clone(false) : NULL),
-    QQ(polarized ? ref->Clone(false) : NULL),
-    QU(polarized ? ref->Clone(false) : NULL),
-    UU(polarized ? ref->Clone(false) : NULL)
+G3SkyMapWeights::G3SkyMapWeights(G3SkyMapConstPtr ref) :
+    TT(ref->Clone(false)), TQ(ref->IsPolarized() ? ref->Clone(false) : NULL),
+    TU(ref->IsPolarized() ? ref->Clone(false) : NULL),
+    QQ(ref->IsPolarized() ? ref->Clone(false) : NULL),
+    QU(ref->IsPolarized() ? ref->Clone(false) : NULL),
+    UU(ref->IsPolarized() ? ref->Clone(false) : NULL)
 {
-	TT->pol_type = G3SkyMap::None;
-	if (polarized){
-		TQ->pol_type = G3SkyMap::None;
-		TU->pol_type = G3SkyMap::None;
-		QQ->pol_type = G3SkyMap::None;
-		QU->pol_type = G3SkyMap::None;
-		UU->pol_type = G3SkyMap::None;
+	TT->pol_type = G3SkyMap::TT;
+	if (ref->IsPolarized()){
+		TQ->pol_type = G3SkyMap::TQ;
+		TU->pol_type = G3SkyMap::TU;
+		QQ->pol_type = G3SkyMap::QQ;
+		QU->pol_type = G3SkyMap::QU;
+		UU->pol_type = G3SkyMap::UU;
 	}
 }
 
@@ -481,11 +496,11 @@ skymap_setitem(G3SkyMap &skymap, ssize_t i, double val)
 void
 G3SkyMap::SetPolConv(G3SkyMap::MapPolConv pol_conv)
 {
-	if (pol_type == G3SkyMap::U && pol_conv == G3SkyMap::ConvNone)
+	if (isumap(*this) && pol_conv == G3SkyMap::ConvNone)
 		log_warn("Map object has pol_type U and unknown pol_conv. "
 			 "Set the pol_conv attribute to IAU or COSMO.");
 
-	if (pol_type != G3SkyMap::U ||
+	if (!isumap(*this) ||
 	    pol_conv == G3SkyMap::ConvNone ||
 	    pol_conv_ == G3SkyMap::ConvNone) {
 		pol_conv_ = pol_conv;
@@ -1426,6 +1441,17 @@ PYBINDINGS("maps") {
 	    .value("E", G3SkyMap::E)
 	    .value("B", G3SkyMap::B)
 	    .value("none", G3SkyMap::None) // "None" is reserved in python
+	    .value("TT", G3SkyMap::TT)
+	    .value("TQ", G3SkyMap::TQ)
+	    .value("TU", G3SkyMap::TU)
+	    .value("QQ", G3SkyMap::QQ)
+	    .value("QU", G3SkyMap::QU)
+	    .value("UU", G3SkyMap::UU)
+	    .value("TE", G3SkyMap::TE)
+	    .value("TB", G3SkyMap::TB)
+	    .value("EE", G3SkyMap::EE)
+	    .value("EB", G3SkyMap::EB)
+	    .value("BB", G3SkyMap::BB)
 	;
 	enum_none_converter::from_python<G3SkyMap::MapPolType>();
 
@@ -1453,6 +1479,8 @@ PYBINDINGS("maps") {
 	      "(e.g. maps.MapPolConv.IAU or maps.MapPolConv.COSMO). "
 	      "Switching between IAU and COSMO conventions for a U map "
 	      "multiplies the U map by -1.")
+	    .add_property("polarized", &G3SkyMap::IsPolarized,
+	      "True if the pol_conv property is set to IAU or COSMO, False otherwise.")
 	    .def_readwrite("units", &G3SkyMap::units,
 	      "Unit class (core.G3TimestreamUnits) of the map (e.g. "
 	      "core.G3TimestreamUnits.Tcmb). Within each unit class, further "
@@ -1674,9 +1702,10 @@ PYBINDINGS("maps") {
 	boost::python::implicitly_convertible<G3SkyMapPtr, G3SkyMapConstPtr>();
 
 	EXPORT_FRAMEOBJECT(G3SkyMapWeights, init<>(),
-	    "Polarized (Mueller matrix) or unpolarized (scalar) map pixel weights.")
-	    .def(bp::init<G3SkyMapConstPtr, bool>(
-	      (bp::arg("skymap"), bp::arg("polarized") = true)))
+	    "Polarized (Mueller matrix) or unpolarized (scalar) map pixel weights."
+	    "Weights are polarized if the pol_conv attribute of the reference map is set.")
+	    .def(bp::init<G3SkyMapConstPtr>(
+	      (bp::arg("skymap"))))
 	    .def_readwrite("TT",&G3SkyMapWeights::TT, "Mueller matrix component map")
 	    .def_readwrite("TQ",&G3SkyMapWeights::TQ, "Mueller matrix component map")
 	    .def_readwrite("TU",&G3SkyMapWeights::TU, "Mueller matrix component map")

--- a/maps/src/G3SkyMap.cxx
+++ b/maps/src/G3SkyMap.cxx
@@ -94,14 +94,14 @@ G3_SERIALIZABLE_CODE(G3SkyMapWeights);
 static bool
 isumap(const G3SkyMap &m)
 {
-  if (m.pol_type == G3SkyMap::U)
-    return true;
-  if (m.pol_type == G3SkyMap::TU)
-    return true;
-  if (m.pol_type == G3SkyMap::QU)
-    return true;
+	if (m.pol_type == G3SkyMap::U)
+		return true;
+	if (m.pol_type == G3SkyMap::TU)
+		return true;
+	if (m.pol_type == G3SkyMap::QU)
+		return true;
 
-  return false;
+	return false;
 }
 
 

--- a/maps/src/G3SkyMapMask.cxx
+++ b/maps/src/G3SkyMapMask.cxx
@@ -15,7 +15,7 @@ G3SkyMapMask::G3SkyMapMask(const G3SkyMap &parent, bool use_data,
 	G3SkyMapPtr tmp = parent.Clone(false);
 	tmp->units = G3Timestream::None;
 	tmp->pol_type = G3SkyMap::None;
-	tmp->SetPolConv(G3SkyMap::ConvNone);
+	tmp->pol_conv = G3SkyMap::ConvNone;
 	tmp->weighted = false;
 	parent_ = tmp;
 	data_ = std::vector<bool>(parent.size());
@@ -31,7 +31,7 @@ G3SkyMapMask::G3SkyMapMask(const G3SkyMap &parent, boost::python::object v,
 	G3SkyMapPtr tmp = parent.Clone(false);
 	tmp->units = G3Timestream::None;
 	tmp->pol_type = G3SkyMap::None;
-	tmp->SetPolConv(G3SkyMap::ConvNone);
+	tmp->pol_conv = G3SkyMap::ConvNone;
 	tmp->weighted = false;
 	parent_ = tmp;
 	data_ = std::vector<bool>(parent.size());

--- a/maps/src/HealpixSkyMap.cxx
+++ b/maps/src/HealpixSkyMap.cxx
@@ -576,7 +576,7 @@ HealpixSkyMap::Clone(bool copy_data) const
 		return boost::make_shared<HealpixSkyMap>(*this);
 	else
 		return boost::make_shared<HealpixSkyMap>(nside(), weighted,
-		    nested(), coord_ref, units, pol_type, info_.shifted(), pol_conv_);
+		    nested(), coord_ref, units, pol_type, info_.shifted(), pol_conv);
 }
 
 double
@@ -869,7 +869,7 @@ HealpixSkyMap::Description() const
 	default:
 		os << "unknown";
 	}
-	switch (pol_conv_) {
+	switch (pol_conv) {
 	case IAU:
 		os << " IAU";
 		break;
@@ -1059,7 +1059,7 @@ G3SkyMapPtr HealpixSkyMap::Rebin(size_t scale, bool norm) const
 		return Clone(true);
 
 	HealpixSkyMapPtr out(new HealpixSkyMap(nside()/scale, weighted,
-	    nested(), coord_ref, units, pol_type, info_.shifted(), pol_conv_));
+	    nested(), coord_ref, units, pol_type, info_.shifted(), pol_conv));
 
 	if (dense_)
 		out->ConvertToDense();

--- a/maps/src/HitsBinner.cxx
+++ b/maps/src/HitsBinner.cxx
@@ -117,7 +117,7 @@ HitsBinner::HitsBinner(std::string output_map_id, const G3SkyMap &stub_map,
 {
 	H_ = stub_map.Clone(false);
 	H_->pol_type = G3SkyMap::None;
-	H_->SetPolConv(G3SkyMap::ConvNone);
+	H_->pol_conv = G3SkyMap::ConvNone;
 	H_->units = G3Timestream::None;
 	H_->weighted = false;
 

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -210,7 +210,7 @@ MapBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 
 		if (map_weights_) {
 			out_frame->Put((Q_) ? "Wpol" : "Wunpol", map_weights_);
-			map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(T_));
+			map_weights_ = map_weights_->Clone(false);
 		}
 
 		out_frame->Put("StartTime", G3TimePtr(new G3Time(start_)));

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -152,8 +152,7 @@ MapBinner::MapBinner(std::string output_map_id, const G3SkyMap &stub_map,
 	T_ = stub_map.Clone(false);
 	T_->pol_type = G3SkyMap::T;
 	if (store_weight_map)
-		map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(T_,
-		    T_->GetPolConv() != G3SkyMap::ConvNone));
+		map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(T_));
 
 	if (T_->GetPolConv() != G3SkyMap::ConvNone) {
 		Q_ = stub_map.Clone(false);
@@ -207,8 +206,7 @@ MapBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 
 		if (map_weights_) {
 			out_frame->Put((Q_) ? "Wpol" : "Wunpol", map_weights_);
-			map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(
-			    T_, T_->GetPolConv() != G3SkyMap::ConvNone));
+			map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(T_));
 		}
 
 		out_frame->Put("StartTime", G3TimePtr(new G3Time(start_)));

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -154,7 +154,7 @@ MapBinner::MapBinner(std::string output_map_id, const G3SkyMap &stub_map,
 	if (store_weight_map)
 		map_weights_ = G3SkyMapWeightsPtr(new G3SkyMapWeights(T_));
 
-	if (T_->GetPolConv() != G3SkyMap::ConvNone) {
+	if (T_->IsPolarized()) {
 		Q_ = stub_map.Clone(false);
 		Q_->pol_type = G3SkyMap::Q;
 		U_ = stub_map.Clone(false);

--- a/maps/src/MapMockObserver.cxx
+++ b/maps/src/MapMockObserver.cxx
@@ -112,9 +112,9 @@ MapMockObserver::MapMockObserver(std::string pointing, std::string timestreams,
 		log_fatal("If simulating polarized maps, pass both Q and U.");
 
 	if (U_) {
-		if (U_->GetPolConv() == G3SkyMap::ConvNone)
+		if (!(U_->IsPolarized()))
 			log_fatal("Missing pol_conv");
-		pol_sign_ = (U_->GetPolConv() == G3SkyMap::COSMO) ? -1 : 1;
+		pol_sign_ = (U_->pol_conv == G3SkyMap::COSMO) ? -1 : 1;
 	}
 }
 

--- a/maps/src/SingleDetectorBoresightBinner.cxx
+++ b/maps/src/SingleDetectorBoresightBinner.cxx
@@ -109,7 +109,7 @@ SingleDetectorBoresightBinner::SingleDetectorBoresightBinner(
 {
 	template_ = stub_map.Clone(false);
 	template_->pol_type = G3SkyMap::T;
-	template_->SetPolConv(G3SkyMap::ConvNone);
+	template_->pol_conv = G3SkyMap::ConvNone;
 }
 
 void

--- a/maps/src/SingleDetectorBoresightBinner.cxx
+++ b/maps/src/SingleDetectorBoresightBinner.cxx
@@ -109,6 +109,7 @@ SingleDetectorBoresightBinner::SingleDetectorBoresightBinner(
 {
 	template_ = stub_map.Clone(false);
 	template_->pol_type = G3SkyMap::T;
+	template_->SetPolConv(G3SkyMap::ConvNone);
 }
 
 void
@@ -172,7 +173,7 @@ SingleDetectorBoresightBinner::Process(G3FramePtr frame,
 			#endif
 		}
 		map_weights_ = G3SkyMapWeightsPtr(
-		    new G3SkyMapWeights(template_, false));
+		    new G3SkyMapWeights(template_));
 	} else {
 		if (template_->units != timestreams->GetUnits())
 			log_fatal("Timestreams have units that do not match "

--- a/maps/src/SingleDetectorMapBinner.cxx
+++ b/maps/src/SingleDetectorMapBinner.cxx
@@ -57,7 +57,7 @@ SingleDetectorMapBinner::SingleDetectorMapBinner(
 {
 	template_ = stub_map.Clone(false);
 	template_->pol_type = G3SkyMap::T;
-	template_->SetPolConv(G3SkyMap::ConvNone);
+	template_->pol_conv = G3SkyMap::ConvNone;
 }
 
 void

--- a/maps/src/SingleDetectorMapBinner.cxx
+++ b/maps/src/SingleDetectorMapBinner.cxx
@@ -57,6 +57,7 @@ SingleDetectorMapBinner::SingleDetectorMapBinner(
 {
 	template_ = stub_map.Clone(false);
 	template_->pol_type = G3SkyMap::T;
+	template_->SetPolConv(G3SkyMap::ConvNone);
 }
 
 void
@@ -120,7 +121,7 @@ SingleDetectorMapBinner::Process(G3FramePtr frame,
 
 			maps_[i.first].first = template_->Clone(false);
 			maps_[i.first].second = G3SkyMapWeightsPtr(
-			    new G3SkyMapWeights(template_, false));
+			    new G3SkyMapWeights(template_));
 #ifdef OPENMP_FOUND
 			// Create a list of detectors to satisfy OpenMP's need
 			// for scalar iteration.

--- a/maps/src/maputils.cxx
+++ b/maps/src/maputils.cxx
@@ -159,11 +159,11 @@ boost::python::tuple GetRaDecMap(G3SkyMapConstPtr m)
 	ra->weighted = false;
 	ra->units = G3Timestream::Angle;
 	ra->pol_type = G3SkyMap::None;
-	ra->SetPolConv(G3SkyMap::ConvNone);
+	ra->pol_conv = G3SkyMap::ConvNone;
 	dec->weighted = false;
 	dec->units = G3Timestream::Angle;
 	dec->pol_type = G3SkyMap::None;
-	dec->SetPolConv(G3SkyMap::ConvNone);
+	dec->pol_conv = G3SkyMap::ConvNone;
 
 	return boost::python::make_tuple(ra, dec);
 }
@@ -203,7 +203,7 @@ G3SkyMapMaskPtr GetRaDecMask(G3SkyMapConstPtr m, double ra_left, double ra_right
 
 void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, G3SkyMapWeightsPtr W, double h, bool invert)
 {
-	if (U->GetPolConv() == G3SkyMap::ConvNone)
+	if (!(U->IsPolarized()))
 		log_warn("Missing pol_conv attribute for flatten_pol, assuming "
 			 "U.pol_conv is set to IAU. This will raise an error "
 			 "in the future.");
@@ -232,7 +232,7 @@ void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, G3SkyMapWeightsPtr W, double h
 		double rot = ATAN2(-grad[0], grad[1]) + ATAN2(-grad[3], -grad[2]);
 		if (invert)
 			rot *= -1.0;
-		if (U->GetPolConv() == G3SkyMap::COSMO)
+		if (U->pol_conv == G3SkyMap::COSMO)
 			rot *= -1.0;
 		double cr = COS(rot);
 		double sr = SIN(rot);
@@ -303,11 +303,11 @@ void ReprojMap(G3SkyMapConstPtr in_map, G3SkyMapPtr out_map, int rebin, bool int
 	}
 
 	double s = 1.;
-	if (out_map->GetPolConv() != G3SkyMap::ConvNone && in_map->GetPolConv() != G3SkyMap::ConvNone) {
-		if (out_map->pol_type == G3SkyMap::U && out_map->GetPolConv() != in_map->GetPolConv())
+	if (out_map->IsPolarized() && in_map->IsPolarized()) {
+		if (out_map->pol_type == G3SkyMap::U && out_map->pol_conv != in_map->pol_conv)
 			s = -1.;
-	} else if (out_map->GetPolConv() == G3SkyMap::ConvNone) {
-		out_map->SetPolConv(in_map->GetPolConv());
+	} else if (!(out_map->IsPolarized())) {
+		out_map->pol_conv = in_map->pol_conv;
 	}
 
 	if (rebin > 1) {

--- a/maps/tests/map_modules.py
+++ b/maps/tests/map_modules.py
@@ -11,7 +11,7 @@ for m in maplist:
     pipe = core.G3Pipeline()
 
     pipe.Add(core.G3InfiniteSource, type=core.G3FrameType.Observation, n=1)
-    pipe.Add(maps.InjectMapStub, map_id="test_map", map_stub=m, polarized=False, weighted=True)
+    pipe.Add(maps.InjectMapStub, map_id="test_map", map_stub=m)
 
     def RandomMap(frame):
         if frame.type != core.G3FrameType.Map:

--- a/maps/tests/map_modules.py
+++ b/maps/tests/map_modules.py
@@ -32,6 +32,11 @@ for m in maplist:
     pipe.Add(mex0)
 
     pipe.Add(maps.MakeMapsPolarized)
+
+    pipe.Add(maps.ValidateMaps)
+    pipe.Add(maps.SetPolConv, pol_conv=maps.MapPolConv.COSMO)
+    pipe.Add(maps.ValidateMaps)
+
     pipe.Add(maps.RemoveWeights)
     pipe.Add(maps.ApplyWeights)
 

--- a/maps/tests/weights_operators.py
+++ b/maps/tests/weights_operators.py
@@ -7,7 +7,8 @@ from spt3g.maps import remove_weights, remove_weights_t, apply_weights, apply_we
 
 for pol in [True, False]:
     # allocation
-    m = FlatSkyMap(500, 20, core.G3Units.arcmin, pol_conv=MapPolConv.IAU, proj=MapProjection.Proj5)
+    pol_conv = MapPolConv.IAU if pol else MapPolConv.none
+    m = FlatSkyMap(500, 20, core.G3Units.arcmin, pol_conv=pol_conv, proj=MapProjection.Proj5)
     mt = m.clone(False)
     mt.pol_type = MapPolType.T
     if pol:
@@ -15,7 +16,7 @@ for pol in [True, False]:
         mq.pol_type = MapPolType.Q
         mu = m.clone(False)
         mu.pol_type = MapPolType.U
-    mw = G3SkyMapWeights(m, polarized=pol)
+    mw = G3SkyMapWeights(m)
     assert(mw.size == m.size)
     assert(mw.shape == m.shape)
     assert(mw.npix_allocated == 0)


### PR DESCRIPTION
Add TT, TQ, etc to the `MapPolType` enumerator, and set the `pol_type` attribute for each map weights item.  Add a new `SetPolConv` pipeline module for changing polarization convention.  Additionally, the TU and QU attributes of a `G3SkyMapWeights` object are multiplied by -1 (along with the U map) if their polarization convention is changed from IAU to COSMO or vice versa using the `SetPolConv` module.  The `G3SkyMap.pol_conv` attribute is now a simple public attribute, and will not result in changing the sign of U/TU/QU maps when updated directly.

Where possible, determine parameters from the input map stub, similarly to the way these are handled in the `MapBinner` pipeline module.  Most notably, the `G3SkyMapWeights` constructor now determines its polarization state based on the `pol_conv` property of the input reference map.  Similarly, the `InjectMapStub` pipeline module determines whether the output frame is weighted and/or polarized based on the properties of the input stub.

