### PR TITLE
Make FlattenPol set flat_pol attribute of T maps and weights

### DIFF
--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -96,9 +96,7 @@ def ApplyWeights(frame):
     frame["T"] = tmap
     if "Wpol" in frame:
         frame["Q"] = qmap
-        frame["U"] = umap
-
-    
+        frame["U"] = umap    
 
     return frame
 

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -98,6 +98,8 @@ def ApplyWeights(frame):
         frame["Q"] = qmap
         frame["U"] = umap
 
+    
+
     return frame
 
 
@@ -125,7 +127,7 @@ def FlattenPol(frame, invert=False):
         return
 
     ValidateMaps(frame)
-    qmap, umap = frame.pop("Q"), frame.pop("U")
+    tmap, qmap, umap = frame.pop("T"), frame.pop("Q"), frame.pop("U")
 
     if "Wpol" in frame:
         wmap = frame.pop("Wpol")
@@ -134,6 +136,9 @@ def FlattenPol(frame, invert=False):
     else:
         maps.flatten_pol(qmap, umap, invert=invert)
 
+    tmap.flat_pol = not invert
+    
+    frame["T"] = tmap
     frame["Q"] = qmap
     frame["U"] = umap
 

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -96,7 +96,7 @@ def ApplyWeights(frame):
     frame["T"] = tmap
     if "Wpol" in frame:
         frame["Q"] = qmap
-        frame["U"] = umap    
+        frame["U"] = umap
 
     return frame
 

--- a/maps/src/maputils.cxx
+++ b/maps/src/maputils.cxx
@@ -263,6 +263,8 @@ void FlattenPol(FlatSkyMapPtr Q, FlatSkyMapPtr U, G3SkyMapWeightsPtr W, double h
 	U->SetFlatPol(!invert);
 
 	if (!!W) {
+		flatptr = boost::dynamic_pointer_cast<FlatSkyMap>(W->TT);
+		flatptr->SetFlatPol(!invert);
 		flatptr = boost::dynamic_pointer_cast<FlatSkyMap>(W->TQ);
 		flatptr->SetFlatPol(!invert);
 		flatptr = boost::dynamic_pointer_cast<FlatSkyMap>(W->TU);


### PR DESCRIPTION
`FlattenPol` sets the `flat_pol` attribute of QU maps and weights to keep track of whether a frame has been flattened, but does not set this attribute for T maps and weights. While `FlattenPol` does not affect T, a frame's T map is often used as a "stub" containing metadata for the generation of subsequent data products. As a result, polarized data products generated from a T stub will not inherit the `flat_pol` attribute as one might expect. After discussion with @arahlin, we decided to make `FlattenPol` modify `flat_pol` for T as well as Q and U.