### PR TITLE
Skip empty files in G3Reader

### DIFF
--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -26,6 +26,7 @@ private:
 	boost::iostreams::filtering_istream stream_;
 	int n_frames_to_read_;
 	int n_frames_read_;
+	int n_frames_cur_;
 	float timeout_;
 	bool track_filename_;
 

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -7,7 +7,8 @@
 G3Reader::G3Reader(std::string filename, int n_frames_to_read,
     float timeout, bool track_filename) :
     prefix_file_(false), n_frames_to_read_(n_frames_to_read),
-    n_frames_read_(0), timeout_(timeout), track_filename_(track_filename)
+    n_frames_read_(0), n_frames_cur_(0), timeout_(timeout),
+    track_filename_(track_filename)
 {
 	boost::filesystem::path fpath(filename);
 	if (filename.find("://") == std::string::npos &&
@@ -20,7 +21,8 @@ G3Reader::G3Reader(std::string filename, int n_frames_to_read,
 G3Reader::G3Reader(std::vector<std::string> filename, int n_frames_to_read,
     float timeout, bool track_filename) :
     prefix_file_(false), n_frames_to_read_(n_frames_to_read),
-    n_frames_read_(0), timeout_(timeout), track_filename_(track_filename)
+    n_frames_read_(0), n_frames_cur_(0), timeout_(timeout),
+    track_filename_(track_filename)
 {
 	if (filename.size() == 0)
 		log_fatal("Empty file list provided to G3Reader");
@@ -41,6 +43,7 @@ void G3Reader::StartFile(std::string path)
 {
 	log_info("Starting file %s\n", path.c_str());
 	cur_file_ = path;
+	n_frames_cur_ = 0;
 	(void) g3_istream_from_path(stream_, path, timeout_);
 }
 
@@ -81,6 +84,8 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 		_save = PyEval_SaveThread();
 
 	while (stream_.peek() == EOF) {
+		if (n_frames_cur_ == 0)
+			log_error("Empty file %s", cur_file_.c_str());
 		if (filename_.size() > 0) {
 			StartFile(filename_.front());
 			filename_.pop_front();
@@ -109,6 +114,7 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	out.push_back(frame);
 
 	n_frames_read_++;
+	n_frames_cur_++;
 }
 
 off_t G3Reader::Seek(off_t offset) {

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -80,7 +80,7 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	if (Py_IsInitialized())
 		_save = PyEval_SaveThread();
 
-	if (stream_.peek() == EOF) {
+	while (stream_.peek() == EOF) {
 		if (filename_.size() > 0) {
 			StartFile(filename_.front());
 			filename_.pop_front();

--- a/core/tests/fileio.py
+++ b/core/tests/fileio.py
@@ -49,6 +49,17 @@ pipe.Run()
 
 assert n == 10, 'Wrong number of frames read (%d should be %d)' % (n, 10)
 
+# Skip empty files
+wr = core.G3Writer("empty.g3")
+del wr
+n = 0
+pipe = core.G3Pipeline()
+pipe.Add(core.G3Reader, filename=["empty.g3", "test.g3", "empty.g3"], track_filename=True)
+pipe.Add(checkinfo)
+pipe.Run()
+
+assert n == 10, 'Wrong number of frames read (%d should be %d)' % (n, 10)
+
 # Indexing
 class CachingReader:
     def __init__(self, filename='test.g3'):


### PR DESCRIPTION
Avoid throwing an IO error when an empty G3 file is included in the input filenames by moving on to the next file in the list, until reaching a non-empty file or the end of the list.  Issues an error message for every empty file that is encountered.

Fixes #134.