### PR TITLE
Allow extra calibration frames to follow proper calframe files in pipelines

### DIFF
--- a/calibration/python/build_cal_frames.py
+++ b/calibration/python/build_cal_frames.py
@@ -355,6 +355,11 @@ class MergeCalibrationFrames(object):
                     self.outframe[k] = frame[k]
             return []
 
+        # Allow extra calibration frames to follow proper calframe files
+        # (which likely have PipelineInfo frames in them)
+        if frame.type == core.G3FrameType.PipelineInfo:
+            return
+
         # Ignore random wiring frames etc.
         if self.outframe is None or len(self.outframe.keys()) == 0:
             return


### PR DESCRIPTION
Calibration frame files often have PipelineInfo frames in them for bookkeeping purposes.  This fix allows multiple calibration frames to be placed into a pipeline in any order, so that they can be merged properly.  This assumes that all of the calibration frames are in order at the beginning of the pipeline, with only PipelineInfo frames potentially interleaving them.