### PR TITLE
Avoid unnecessary error log messages in MapBinner

### DIFF
--- a/maps/src/HitsBinner.cxx
+++ b/maps/src/HitsBinner.cxx
@@ -171,6 +171,7 @@ HitsBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 
 	if (!frame->Has(timestreams_)) {
+		log_info("Missing timestreams %s", timestreams_.c_str());
 		out.push_back(frame);
 		return;
 	}

--- a/maps/src/HitsBinner.cxx
+++ b/maps/src/HitsBinner.cxx
@@ -149,6 +149,10 @@ HitsBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 	
 	if (emit_map_now) {
+		if (start_.time == 0)
+			log_error("No valid scan frames found for map %s",
+			    output_id_.c_str());
+
 		G3FramePtr out_frame(new G3Frame(G3Frame::Map));
 		out_frame->Put("Id", G3StringPtr(new G3String(output_id_)));
 		out_frame->Put("H", boost::dynamic_pointer_cast<G3FrameObject>(H_));
@@ -162,6 +166,11 @@ HitsBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 
 	if (frame->type != G3Frame::Scan) {
+		out.push_back(frame);
+		return;
+	}
+
+	if (!frame->Has(timestreams_)) {
 		out.push_back(frame);
 		return;
 	}

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -190,6 +190,10 @@ MapBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 	
 	if (emit_map_now) {
+		if (start_.time == 0)
+			log_error("No valid scan frames found for map %s",
+			    output_id_.c_str());
+
 		G3FramePtr out_frame(new G3Frame(G3Frame::Map));
 		out_frame->Put("Id", G3StringPtr(new G3String(output_id_)));
 		out_frame->Put("T",
@@ -219,6 +223,11 @@ MapBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 
 	if (frame->type != G3Frame::Scan) {
+		out.push_back(frame);
+		return;
+	}
+
+	if (!frame->Has(timestreams_)) {
 		out.push_back(frame);
 		return;
 	}

--- a/maps/src/MapBinner.cxx
+++ b/maps/src/MapBinner.cxx
@@ -228,6 +228,7 @@ MapBinner::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	}
 
 	if (!frame->Has(timestreams_)) {
+		log_info("Missing timestreams %s", timestreams_.c_str());
 		out.push_back(frame);
 		return;
 	}


### PR DESCRIPTION
When multiple MapBinners are used in a single pipeline with temporally-split timestreams (e.g. separate maps for left and right scans), each binner emits an error message when it doesn't find the appropriate timestreams in every scan frame.  This PR is intended to avoid these unnecessary error messages, and instead issue a single error message if an empty map is emitted at the end of the pipeline.