### PR TITLE
Testing environment cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,15 +153,8 @@ endforeach(subdir ${SUBDIRS})
 export(TARGETS ${SPT3G_LIBRARIES} NAMESPACE spt3g:: FILE ${CMAKE_BINARY_DIR}/cmake/Spt3gTargets.cmake)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Spt3gConfig.cmake.in ${CMAKE_BINARY_DIR}/cmake/Spt3gConfig.cmake @ONLY)
 
-# Add fetching of test data
-add_custom_target(testdata COMMAND rsync -vrlpt --delete rsync://bolo.berkeley.edu/testdata ${CMAKE_BINARY_DIR}/testdata COMMENT "Rsyncing test data from bolo.berkeley.edu")
-
-add_custom_target(fasttest COMMAND ctest -LE SLOWTEST COMMENT "Running fast test suite")
-
 # Custom things related to testing
-configure_file(${CMAKE_SOURCE_DIR}/cmake/test_env.py.in ${CMAKE_BINARY_DIR}/test_env.py @ONLY)
-configure_file(${CMAKE_SOURCE_DIR}/cmake/CTestCustom.cmake.in ${CMAKE_BINARY_DIR}/CTestCustom.cmake @ONLY)
-
+add_custom_target(fasttest COMMAND ctest -LE SLOWTEST COMMENT "Running fast test suite")
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
 	list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 endif(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)

--- a/cmake/CTestCustom.cmake.in
+++ b/cmake/CTestCustom.cmake.in
@@ -1,1 +1,0 @@
-execute_process(COMMAND python test_env.py)

--- a/cmake/Spt3gIncludes.cmake.in
+++ b/cmake/Spt3gIncludes.cmake.in
@@ -65,10 +65,12 @@ macro(add_spt3g_library lib_name)
 endmacro(add_spt3g_library lib_name)
 
 macro(add_spt3g_test test_name)
-	add_test(${PROJECT}/${test_name} ${SPT3G_BUILD_DIR}/env-shell.sh ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/${test_name}.py)
+	add_test(${PROJECT}/${test_name} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/${test_name}.py)
 
 	set(extra_macro_args ${ARGN})
 	list(LENGTH extra_macro_args num_extra_args)
+	set_tests_properties(${PROJECT}/${test_name} PROPERTIES ENVIRONMENT
+		"PATH=${SPT3G_BUILD_DIR}/bin:$ENV{PATH};PYTHONPATH=${SPT3G_BUILD_DIR}:$ENV{PYTHONPATH};LD_LIBRARY_PATH=${SPT3G_BUILD_DIR}/spt3g:$ENV{LD_LIBRARY_PATH}")
 	if (${num_extra_args} GREATER 0)
 		list(GET extra_macro_args 0 test_labels)
 		set_tests_properties(${PROJECT}/${test_name} PROPERTIES LABELS ${test_labels})

--- a/cmake/test_env.py.in
+++ b/cmake/test_env.py.in
@@ -1,8 +1,0 @@
-from __future__ import print_function
-import os, sys
-
-if not ('SPT3G_SOFTWARE_BUILD_PATH' in os.environ):
-    if sys.stderr.isatty():
-        print('\033[0;31mWARNING: Environment not set!\033[0m', file=sys.stderr)
-    else:
-        print('WARNING: Environment not set!', file=sys.stderr)

--- a/core/tests/portability.py
+++ b/core/tests/portability.py
@@ -6,7 +6,7 @@ import os, sys
 # Test that we can read files written on a variety of platforms. Pass a path
 # to generate test data for whatever this platform is.
 
-testpath = os.path.join(os.environ['SPT3G_SOFTWARE_PATH'], 'core/tests/portability')
+testpath = os.path.join(os.path.dirname(__file__), "portability")
 
 # Test data. Exercise some complicated things (STL bits) that we don't
 # necessarily have control over, mapping a few primitive types.


### PR DESCRIPTION
Set path environment variables for tests from the build directory.  Ensures that the correct libraries are always used, without having to make changes to the parent shell environment.