### PR TITLE
Update compiler requirements for C++14

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ This depends on Boost and cmake, as well as the usual Python packages. Some addi
 
 Minimum versions:
 
-	- GCC >= 4.7 or clang >= 3.3
+	- GCC >= 5.0 or clang >= 3.4
 	- Boost >= 1.48
 	- cmake >= 3.1
 	- Python >= 2.7 (although pre-Python-3 support is best-effort)


### PR DESCRIPTION
Follow-up to https://github.com/CMB-S4/spt3g_software/pull/148. 