### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 if(POLICY CMP0060) # Avoid cmake misfeature that can link the wrong libraries
 	cmake_policy(SET CMP0060 NEW)
 endif()

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Minimum versions:
 
 	- GCC >= 4.7 or clang >= 3.3
 	- Boost >= 1.48
-	- cmake >= 3.1
+	- cmake >= 3.5
 	- Python >= 2.7 (although pre-Python-3 support is best-effort)
 
 On Ubuntu/Debian, you can install the non-Python dependencies, including the optional ones, by doing:


### PR DESCRIPTION
The latest version of cmake (3.28.3) warns that versions < 3.5 will not be supported in the near future.