### PR TITLE
Update dfmux HousekeepingConsumer for mkids firmware

### DIFF
--- a/dfmux/include/dfmux/Housekeeping.h
+++ b/dfmux/include/dfmux/Housekeeping.h
@@ -71,7 +71,7 @@ public:
         nuller_gain(-1), demod_gain(-1), carrier_railed(false), nuller_railed(false),
         demod_railed(false), squid_flux_bias(NAN), squid_current_bias(NAN),
 	squid_stage1_offset(NAN), squid_p2p(NAN), squid_transimpedance(NAN),
-	nco_frequency (NAN) {}
+	nco_frequency(NAN) {}
 
 	int32_t module_number; // 1-indexed
 

--- a/dfmux/include/dfmux/Housekeeping.h
+++ b/dfmux/include/dfmux/Housekeeping.h
@@ -70,7 +70,8 @@ public:
 	HkModuleInfo() : G3FrameObject(), module_number(-1), carrier_gain(-1),
         nuller_gain(-1), demod_gain(-1), carrier_railed(false), nuller_railed(false),
         demod_railed(false), squid_flux_bias(NAN), squid_current_bias(NAN),
-        squid_stage1_offset(NAN), squid_p2p(NAN), squid_transimpedance(NAN) {}
+	squid_stage1_offset(NAN), squid_p2p(NAN), squid_transimpedance(NAN),
+	nco_frequency (NAN) {}
 
 	int32_t module_number; // 1-indexed
 
@@ -93,6 +94,8 @@ public:
 	std::string squid_feedback;
 	std::string routing_type;
 
+	double nco_frequency;
+
 	std::map<int32_t, HkChannelInfo> channels; // 1-indexed
 
 	template <class A> void serialize(A &ar, unsigned v);
@@ -100,7 +103,7 @@ public:
 };
 
 G3_POINTERS(HkModuleInfo);
-G3_SERIALIZABLE(HkModuleInfo, 2);
+G3_SERIALIZABLE(HkModuleInfo, 3);
 
 class HkMezzanineInfo : public G3FrameObject
 {
@@ -136,15 +139,16 @@ G3_SERIALIZABLE(HkMezzanineInfo, 2);
 class HkBoardInfo : public G3FrameObject
 {
 public:
-	HkBoardInfo() : G3FrameObject(), fir_stage(-1), is128x(false), isv4(false) {}
+	HkBoardInfo() : G3FrameObject(), fir_stage(-1), is128x(false) {}
 
 	G3Time timestamp;
 
 	std::string timestamp_port;
 	std::string serial;
+	std::string firmware_version;
+	std::string firmware_name;
 	int32_t fir_stage;
 	bool is128x;
-	bool isv4;
 
 	std::map<std::string, double> currents;
 	std::map<std::string, double> voltages;

--- a/dfmux/include/dfmux/Housekeeping.h
+++ b/dfmux/include/dfmux/Housekeeping.h
@@ -25,7 +25,9 @@ public:
 	HkChannelInfo() : G3FrameObject(), channel_number(-1), carrier_amplitude(NAN),
         carrier_frequency(NAN), dan_accumulator_enable(false), dan_feedback_enable(false),
         dan_streaming_enable(false), dan_gain(NAN), demod_frequency(NAN), nuller_amplitude(NAN),
-        dan_railed(false), rlatched(NAN), rnormal(NAN), rfrac_achieved(NAN), loopgain(NAN) {}
+	dan_railed(false), rlatched(NAN), rnormal(NAN), rfrac_achieved(NAN), loopgain(NAN),
+	carrier_phase(NAN), nuller_phase(NAN), demod_phase(NAN), dan_zero_enable(false),
+	dan_zeroed(false) {}
 
 	int32_t channel_number; // 1-indexed
 	double carrier_amplitude;
@@ -45,12 +47,20 @@ public:
 	double rfrac_achieved;
 	double loopgain;
 
+	// hidfmux properties
+	double carrier_phase;
+	double nuller_phase;
+	double demod_phase;
+
+	bool dan_zero_enable;
+	bool dan_zeroed;
+
 	template <class A> void serialize(A &ar, unsigned v);
 	std::string Description() const;
 };
 
 G3_POINTERS(HkChannelInfo);
-G3_SERIALIZABLE(HkChannelInfo, 5);
+G3_SERIALIZABLE(HkChannelInfo, 6);
 
 class HkModuleInfo : public G3FrameObject
 {
@@ -124,7 +134,7 @@ G3_SERIALIZABLE(HkMezzanineInfo, 2);
 class HkBoardInfo : public G3FrameObject
 {
 public:
-	HkBoardInfo() : G3FrameObject(), fir_stage(-1), is128x(false) {}
+	HkBoardInfo() : G3FrameObject(), fir_stage(-1), is128x(false), isv4(false) {}
 
 	G3Time timestamp;
 
@@ -132,6 +142,7 @@ public:
 	std::string serial;
 	int32_t fir_stage;
 	bool is128x;
+	bool isv4;
 
 	std::map<std::string, double> currents;
 	std::map<std::string, double> voltages;
@@ -144,7 +155,7 @@ public:
 };
 
 G3_POINTERS(HkBoardInfo);
-G3_SERIALIZABLE(HkBoardInfo, 2);
+G3_SERIALIZABLE(HkBoardInfo, 3);
 
 G3MAP_OF(int32_t, HkBoardInfo, DfMuxHousekeepingMap);
 

--- a/dfmux/include/dfmux/Housekeeping.h
+++ b/dfmux/include/dfmux/Housekeeping.h
@@ -26,8 +26,8 @@ public:
         carrier_frequency(NAN), dan_accumulator_enable(false), dan_feedback_enable(false),
         dan_streaming_enable(false), dan_gain(NAN), demod_frequency(NAN), nuller_amplitude(NAN),
 	dan_railed(false), rlatched(NAN), rnormal(NAN), rfrac_achieved(NAN), loopgain(NAN),
-	carrier_phase(NAN), nuller_phase(NAN), demod_phase(NAN), dan_zero_enable(false),
-	dan_zeroed(false) {}
+	demod_amplitude(NAN), carrier_phase(NAN), nuller_phase(NAN), demod_phase(NAN),
+	dan_zero_enable(false), dan_zeroed(false) {}
 
 	int32_t channel_number; // 1-indexed
 	double carrier_amplitude;
@@ -48,6 +48,8 @@ public:
 	double loopgain;
 
 	// hidfmux properties
+	double demod_amplitude;
+
 	double carrier_phase;
 	double nuller_phase;
 	double demod_phase;

--- a/dfmux/include/dfmux/Housekeeping.h
+++ b/dfmux/include/dfmux/Housekeeping.h
@@ -26,8 +26,7 @@ public:
         carrier_frequency(NAN), dan_accumulator_enable(false), dan_feedback_enable(false),
         dan_streaming_enable(false), dan_gain(NAN), demod_frequency(NAN), nuller_amplitude(NAN),
 	dan_railed(false), rlatched(NAN), rnormal(NAN), rfrac_achieved(NAN), loopgain(NAN),
-	demod_amplitude(NAN), carrier_phase(NAN), nuller_phase(NAN), demod_phase(NAN),
-	dan_zero_enable(false), dan_zeroed(false) {}
+	carrier_phase(NAN), nuller_phase(NAN), demod_phase(NAN) {}
 
 	int32_t channel_number; // 1-indexed
 	double carrier_amplitude;
@@ -48,14 +47,9 @@ public:
 	double loopgain;
 
 	// hidfmux properties
-	double demod_amplitude;
-
 	double carrier_phase;
 	double nuller_phase;
 	double demod_phase;
-
-	bool dan_zero_enable;
-	bool dan_zeroed;
 
 	template <class A> void serialize(A &ar, unsigned v);
 	std::string Description() const;

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -215,8 +215,9 @@ class HousekeepingConsumer(object):
 
         boardhk.timestamp_port = str(dat['timestamp_port'])
         boardhk.serial = str(dat['serial'])
-        boardhk.firmware_name = str(dat.get('firmware_name', ''))
-        boardhk.firmware_version = str(dat.get('firmware_version', ''))
+        if 'firmware_name' in dat:
+            boardhk.firmware_name = str(dat['firmware_name'])
+            boardhk.firmware_version = str(dat['firmware_version'])
         boardhk.fir_stage = dat['fir_stage']
         for i in dat['currents'].items():
             boardhk.currents[str(i[0])] = i[1]
@@ -231,13 +232,16 @@ class HousekeepingConsumer(object):
             mezzhk.present = mezz['present']
             mezzhk.power = mezz['power']
             if mezzhk.present:
-                mezzhk.serial = str(mezz['ipmi']['product']['serial_number'])
-                mezzhk.part_number = str(mezz['ipmi']['product']['part_number'])
-                mezzhk.revision = str(mezz['ipmi']['product']['version_number'])
-                for i in mezz['currents'].items():
-                    mezzhk.currents[str(i[0])] = i[1]
-                for i in mezz['voltages'].items():
-                    mezzhk.voltages[str(i[0])] = i[1]
+                if 'ipmi' in mezz:
+                    mezzhk.serial = str(mezz['ipmi']['product']['serial_number'])
+                    mezzhk.part_number = str(mezz['ipmi']['product']['part_number'])
+                    mezzhk.revision = str(mezz['ipmi']['product']['version_number'])
+                if 'currents' in mezz:
+                    for i in mezz['currents'].items():
+                        mezzhk.currents[str(i[0])] = i[1]
+                if 'voltages' in mezz:
+                    for i in mezz['voltages'].items():
+                        mezzhk.voltages[str(i[0])] = i[1]
 
             if mezzhk.present and mezzhk.power:
                 if 'temperature' in mezz:

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -216,7 +216,6 @@ class HousekeepingConsumer(object):
         boardhk.timestamp_port = str(dat['timestamp_port'])
         boardhk.serial = str(dat['serial'])
         boardhk.firmware_name = str(dat.get('firmware_name', ''))
-        ismkid = 'mkid' in board.firmware_name.lower()
         boardhk.firmware_version = str(dat.get('firmware_version', ''))
         boardhk.fir_stage = dat['fir_stage']
         for i in dat['currents'].items():
@@ -279,22 +278,23 @@ class HousekeepingConsumer(object):
                     chanhk.channel_number = k+1
                     chanhk.carrier_amplitude = chan['carrier_amplitude']
                     chanhk.nuller_amplitude = chan['nuller_amplitude']
-                    chanhk.dan_gain = chan['dan_gain']
-                    chanhk.dan_streaming_enable = chan['dan_streaming_enable']
-                    if boardhk.is128x or ismkid:
-                        chanhk.carrier_frequency = chan['frequency']*core.G3Units.Hz
-                        chanhk.demod_frequency = chan['frequency']*core.G3Units.Hz
-                        if ismkid:
-                            chanhk.demod_amplitude = chan['demod_amplitude']
-                            chanhk.carrier_phase = chan['carrier_phase'] * core.G3Units.rad
-                            chanhk.nuller_phase = chan['nuller_phase'] * core.G3Units.rad
-                            chanhk.demod_phase = chan['demod_phase'] * core.G3Units.rad
-                            chanhk.dan_zero_enable = chan['dan_zero_enable']
-                            chanhk.dan_zeroed = chan['dan_zeroed']
+                    if 'dan_gain' in chan:
+                        chanhk.dan_gain = chan['dan_gain']
+                    if 'dan_streaming_enable' in chan:
+                        chanhk.dan_streaming_enable = chan['dan_streaming_enable']
+                    if 'frequency' in chan:
+                        chanhk.carrier_frequency = chan['frequency'] * core.G3Units.Hz
+                        chanhk.demod_frequency = chan['frequency'] * core.G3Units.Hz
                     else:
-                        chanhk.carrier_frequency = chan['carrier_frequency']*core.G3Units.Hz
-                        chanhk.demod_frequency = chan['demod_frequency']*core.G3Units.Hz
+                        chanhk.carrier_frequency = chan['carrier_frequency'] * core.G3Units.Hz
+                        chanhk.demod_frequency = chan['demod_frequency'] * core.G3Units.Hz
+                    if 'carrier_phase' in chan:
+                        chanhk.carrier_phase = chan['carrier_phase'] * core.G3Units.deg
+                        chanhk.nuller_phase = chan['nuller_phase'] * core.G3Units.deg
+                        chanhk.demod_phase = chan['demod_phase'] * core.G3Units.deg
+                    if 'dan_accumulator_enable' in chan:
                         chanhk.dan_accumulator_enable = chan['dan_accumulator_enable']
+                    if 'dan_feedback_enable' in chan:
                         chanhk.dan_feedback_enable = chan['dan_feedback_enable']
                     if 'dan_railed' in chan:
                         chanhk.dan_railed = chan['dan_railed']

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -240,7 +240,8 @@ class HousekeepingConsumer(object):
                     mezzhk.voltages[str(i[0])] = i[1]
 
             if mezzhk.present and mezzhk.power:
-                mezzhk.temperature = mezz['temperature']
+                if 'temperature' in mezz:
+                    mezzhk.temperature = mezz['temperature']
                 # these parameters are not in the 64x housekeeping tuber
                 mezzhk.squid_heater = mezz.get('squid_heater', 0.0)
                 mezzhk.squid_controller_power = mezz.get('squid_controller_power', False)

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -242,8 +242,7 @@ class HousekeepingConsumer(object):
                     mezzhk.voltages[str(i[0])] = i[1]
 
             if mezzhk.present and mezzhk.power:
-                # this is not present in v4 firmware
-                mezzhk.temperature = mezz.get('temperature', 0.0)
+                mezzhk.temperature = mezz['temperature']
                 # these parameters are not in the 64x housekeeping tuber
                 mezzhk.squid_heater = mezz.get('squid_heater', 0.0)
                 mezzhk.squid_controller_power = mezz.get('squid_controller_power', False)
@@ -281,17 +280,16 @@ class HousekeepingConsumer(object):
                     chanhk.nuller_amplitude = chan['nuller_amplitude']
                     chanhk.dan_gain = chan['dan_gain']
                     chanhk.dan_streaming_enable = chan['dan_streaming_enable']
-                    if boardhk.isv4:
-                        chanhk.carrier_frequency = chan['frequency'] * core.G3Units.Hz
-                        chanhk.demod_frequency = chan['frequency'] * core.G3Units.Hz
-                        chanhk.carrier_phase = chan['carrier_phase'] * core.G3Units.rad
-                        chanhk.nuller_phase = chan['nuller_phase'] * core.G3Units.rad
-                        chanhk.demod_phase = chan['demod_phase'] * core.G3Units.rad
-                        chanhk.dan_zero_enable = chan['dan_zero_enable']
-                        chanhk.dan_zeroed = chan['dan_zeroed']
-                    elif boardhk.is128x:
+                    if boardhk.is128x or boardhk.isv4:
                         chanhk.carrier_frequency = chan['frequency']*core.G3Units.Hz
                         chanhk.demod_frequency = chan['frequency']*core.G3Units.Hz
+                        if boardhk.isv4:
+                            chanhk.demod_amplitude = chan['demod_amplitude']
+                            chanhk.carrier_phase = chan['carrier_phase'] * core.G3Units.rad
+                            chanhk.nuller_phase = chan['nuller_phase'] * core.G3Units.rad
+                            chanhk.demod_phase = chan['demod_phase'] * core.G3Units.rad
+                            chanhk.dan_zero_enable = chan['dan_zero_enable']
+                            chanhk.dan_zeroed = chan['dan_zeroed']
                     else:
                         chanhk.carrier_frequency = chan['carrier_frequency']*core.G3Units.Hz
                         chanhk.demod_frequency = chan['demod_frequency']*core.G3Units.Hz

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -126,10 +126,12 @@ class HousekeepingConsumer(object):
                                      # avoid overloading the network on the return
 
                 found = False
+                isv4 = False
                 for board in self.board_serials:
                     dat = self.tuber[board].GetReply()[0]['result']
 
                     boardhk = self.HousekeepingFromJSON(dat)
+                    isv4 = isv4 or boardhk.isv4
                     hkdata[int(boardhk.serial)] = boardhk
 
                     ip, crate, slot = self.board_map[board]
@@ -149,7 +151,7 @@ class HousekeepingConsumer(object):
 
                 hwmf = core.G3Frame(core.G3FrameType.Wiring)
                 hwmf['WiringMap'] = hwm
-                hwmf['ReadoutSystem'] = 'ICE'
+                hwmf['ReadoutSystem'] = 'ICE4' if isv4 else 'ICE'
 
                 if self.hwmf is None:
                     self.hwmf = hwmf

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -151,7 +151,7 @@ class HousekeepingConsumer(object):
 
                 hwmf = core.G3Frame(core.G3FrameType.Wiring)
                 hwmf['WiringMap'] = hwm
-                hwmf['ReadoutSystem'] = 'ICE-MKID' if ismkid else 'ICE'
+                hwmf['ReadoutSystem'] = 'RF-ICE' if ismkid else 'ICE'
 
                 if self.hwmf is None:
                     self.hwmf = hwmf

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -131,7 +131,8 @@ class HousekeepingConsumer(object):
                     dat = self.tuber[board].GetReply()[0]['result']
 
                     boardhk = self.HousekeepingFromJSON(dat)
-                    ismkid = ismkid or "mkid" in boardhk.firmware_name.lower()
+                    if boardhk.firmware_name:
+                        ismkid = ismkid or "mkid" in boardhk.firmware_name.lower()
                     hkdata[int(boardhk.serial)] = boardhk
 
                     ip, crate, slot = self.board_map[board]

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -50,6 +50,7 @@ template <class A> void HkChannelInfo::serialize(A &ar, unsigned v)
 	}
 
 	if (v > 5) {
+		ar & make_nvp("demod_amplitude", demod_amplitude);
 		ar & make_nvp("carrier_phase", carrier_phase);
 		ar & make_nvp("nuller_phase", nuller_phase);
 		ar & make_nvp("demod_phase", demod_phase);
@@ -209,6 +210,8 @@ PYBINDINGS("dfmux") {
 	    .def_readwrite("loopgain", &HkChannelInfo::loopgain,
 	       "Measured loopgain of the detector as stored by the "
 	       "control software tuning script.")
+	    .def_readwrite("demod_amplitude", &HkChannelInfo::demod_amplitude,
+	       "Demodulator amplitude in normalized units (0-1) (v4 only)")
 	    .def_readwrite("carrier_phase", &HkChannelInfo::carrier_phase,
 	       "Carrier phase in standard angle units (v4 only)")
 	    .def_readwrite("nuller_phase", &HkChannelInfo::nuller_phase,

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -92,6 +92,10 @@ template <class A> void HkModuleInfo::serialize(A &ar, unsigned v)
 		ar & make_nvp("squid_p2p", squid_p2p);
 		ar & make_nvp("squid_transimpedance", squid_transimpedance);
 	}
+
+	if (v >= 3) {
+		ar & make_nvp("nco_frequency", nco_frequency);
+	}
 }
 
 std::string HkMezzanineInfo::Description() const
@@ -157,7 +161,8 @@ template <class A> void HkBoardInfo::serialize(A &ar, unsigned v)
 	}
 
 	if (v >= 3) {
-		ar & make_nvp("isv4", isv4);
+		ar & make_nvp("firmware_version", firmware_version);
+		ar & make_nvp("firmware_name", firmware_name);
 	}
 }
 
@@ -211,17 +216,17 @@ PYBINDINGS("dfmux") {
 	       "Measured loopgain of the detector as stored by the "
 	       "control software tuning script.")
 	    .def_readwrite("demod_amplitude", &HkChannelInfo::demod_amplitude,
-	       "Demodulator amplitude in normalized units (0-1) (v4 only)")
+	       "Demodulator amplitude in normalized units (0-1) (mkid only)")
 	    .def_readwrite("carrier_phase", &HkChannelInfo::carrier_phase,
-	       "Carrier phase in standard angle units (v4 only)")
+	       "Carrier phase in standard angle units (mkid only)")
 	    .def_readwrite("nuller_phase", &HkChannelInfo::nuller_phase,
-	       "Nuller phase in standard angle units (v4 only)")
+	       "Nuller phase in standard angle units (mkid only)")
 	    .def_readwrite("demod_phase", &HkChannelInfo::demod_phase,
-	       "Demodulator phase in standard angle units (v4 only)")
+	       "Demodulator phase in standard angle units (mkid only)")
 	    .def_readwrite("dan_zero_enable", &HkChannelInfo::dan_zero_enable,
-	       "True if the DAN zero enable functionality is turned on (v4 only)")
+	       "True if the DAN zero enable functionality is turned on (mkid only)")
 	    .def_readwrite("dan_zeroed", &HkChannelInfo::dan_zeroed,
-	       "True if the DAN channel is zeroed (v4 only)")
+	       "True if the DAN channel is zeroed (mkid only)")
 	;
 	register_map<std::map<int, HkChannelInfo> >("HkChannelInfoMap",
 	    "Mapping of channel number (1-indexed) to channel status "
@@ -258,6 +263,9 @@ PYBINDINGS("dfmux") {
 	       "tuning script to describe SQUID state")
 	    .def_readwrite("squid_feedback", &HkModuleInfo::squid_feedback,
 	       "SQUID feedback mechanism employed")
+	    .def_readwrite("nco_frequency",
+	       &HkModuleInfo::nco_frequency,
+	       "NCO frequency in standard frequency units (mkid only)")
 	    .def_readwrite("routing_type", &HkModuleInfo::routing_type,
 	       "Whether DAC are routed directly to ADCs or to the cryostat")
 	    .def_readwrite("channels", &HkModuleInfo::channels,
@@ -313,8 +321,10 @@ PYBINDINGS("dfmux") {
 	       "faster and grow by factors of two with each decrement")
 	    .def_readwrite("is128x", &HkBoardInfo::is128x,
 		"Boolean for whether 128x firmware is running")
-	    .def_readwrite("isv4", &HkBoardInfo::isv4,
-		"Boolean for whether v4 firmware is running")
+	    .def_readwrite("firmware_version", &HkBoardInfo::firmware_version,
+	       "Firmware version")
+	    .def_readwrite("firmware_name", &HkBoardInfo::firmware_name,
+	       "Firmware name")
 	    .def_readwrite("currents", &HkBoardInfo::currents,
 	       "Dictionary of data from on-board current sensors")
 	    .def_readwrite("voltages", &HkBoardInfo::voltages,

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -50,12 +50,9 @@ template <class A> void HkChannelInfo::serialize(A &ar, unsigned v)
 	}
 
 	if (v > 5) {
-		ar & make_nvp("demod_amplitude", demod_amplitude);
 		ar & make_nvp("carrier_phase", carrier_phase);
 		ar & make_nvp("nuller_phase", nuller_phase);
 		ar & make_nvp("demod_phase", demod_phase);
-		ar & make_nvp("dan_zero_enable", dan_zero_enable);
-		ar & make_nvp("dan_zeroed", dan_zeroed);
 	}
 }
 
@@ -215,18 +212,12 @@ PYBINDINGS("dfmux") {
 	    .def_readwrite("loopgain", &HkChannelInfo::loopgain,
 	       "Measured loopgain of the detector as stored by the "
 	       "control software tuning script.")
-	    .def_readwrite("demod_amplitude", &HkChannelInfo::demod_amplitude,
-	       "Demodulator amplitude in normalized units (0-1) (mkid only)")
 	    .def_readwrite("carrier_phase", &HkChannelInfo::carrier_phase,
 	       "Carrier phase in standard angle units (mkid only)")
 	    .def_readwrite("nuller_phase", &HkChannelInfo::nuller_phase,
 	       "Nuller phase in standard angle units (mkid only)")
 	    .def_readwrite("demod_phase", &HkChannelInfo::demod_phase,
 	       "Demodulator phase in standard angle units (mkid only)")
-	    .def_readwrite("dan_zero_enable", &HkChannelInfo::dan_zero_enable,
-	       "True if the DAN zero enable functionality is turned on (mkid only)")
-	    .def_readwrite("dan_zeroed", &HkChannelInfo::dan_zeroed,
-	       "True if the DAN channel is zeroed (mkid only)")
 	;
 	register_map<std::map<int, HkChannelInfo> >("HkChannelInfoMap",
 	    "Mapping of channel number (1-indexed) to channel status "

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -263,8 +263,7 @@ PYBINDINGS("dfmux") {
 	       "tuning script to describe SQUID state")
 	    .def_readwrite("squid_feedback", &HkModuleInfo::squid_feedback,
 	       "SQUID feedback mechanism employed")
-	    .def_readwrite("nco_frequency",
-	       &HkModuleInfo::nco_frequency,
+	    .def_readwrite("nco_frequency", &HkModuleInfo::nco_frequency,
 	       "NCO frequency in standard frequency units (mkid only)")
 	    .def_readwrite("routing_type", &HkModuleInfo::routing_type,
 	       "Whether DAC are routed directly to ADCs or to the cryostat")

--- a/dfmux/src/Housekeeping.cxx
+++ b/dfmux/src/Housekeeping.cxx
@@ -48,6 +48,14 @@ template <class A> void HkChannelInfo::serialize(A &ar, unsigned v)
 	if (v > 4) {
 		ar & make_nvp("loopgain", loopgain);
 	}
+
+	if (v > 5) {
+		ar & make_nvp("carrier_phase", carrier_phase);
+		ar & make_nvp("nuller_phase", nuller_phase);
+		ar & make_nvp("demod_phase", demod_phase);
+		ar & make_nvp("dan_zero_enable", dan_zero_enable);
+		ar & make_nvp("dan_zeroed", dan_zeroed);
+	}
 }
 
 std::string HkModuleInfo::Description() const
@@ -146,6 +154,10 @@ template <class A> void HkBoardInfo::serialize(A &ar, unsigned v)
 	if (v >= 2) {
 		ar & make_nvp("is128x", is128x);
 	}
+
+	if (v >= 3) {
+		ar & make_nvp("isv4", isv4);
+	}
 }
 
 G3_SERIALIZABLE_CODE(HkChannelInfo);
@@ -197,6 +209,16 @@ PYBINDINGS("dfmux") {
 	    .def_readwrite("loopgain", &HkChannelInfo::loopgain,
 	       "Measured loopgain of the detector as stored by the "
 	       "control software tuning script.")
+	    .def_readwrite("carrier_phase", &HkChannelInfo::carrier_phase,
+	       "Carrier phase in standard angle units (v4 only)")
+	    .def_readwrite("nuller_phase", &HkChannelInfo::nuller_phase,
+	       "Nuller phase in standard angle units (v4 only)")
+	    .def_readwrite("demod_phase", &HkChannelInfo::demod_phase,
+	       "Demodulator phase in standard angle units (v4 only)")
+	    .def_readwrite("dan_zero_enable", &HkChannelInfo::dan_zero_enable,
+	       "True if the DAN zero enable functionality is turned on (v4 only)")
+	    .def_readwrite("dan_zeroed", &HkChannelInfo::dan_zeroed,
+	       "True if the DAN channel is zeroed (v4 only)")
 	;
 	register_map<std::map<int, HkChannelInfo> >("HkChannelInfoMap",
 	    "Mapping of channel number (1-indexed) to channel status "
@@ -288,6 +310,8 @@ PYBINDINGS("dfmux") {
 	       "faster and grow by factors of two with each decrement")
 	    .def_readwrite("is128x", &HkBoardInfo::is128x,
 		"Boolean for whether 128x firmware is running")
+	    .def_readwrite("isv4", &HkBoardInfo::isv4,
+		"Boolean for whether v4 firmware is running")
 	    .def_readwrite("currents", &HkBoardInfo::currents,
 	       "Dictionary of data from on-board current sensors")
 	    .def_readwrite("voltages", &HkBoardInfo::voltages,


### PR DESCRIPTION
Add optional entries for RF-ICE properties in housekeeping dump.  Also use a different `ReadoutSystem` entry in the wiring frame (`"RF-ICE"` instead of `"ICE"`), for use later in converting timestreams into physical units.

Maintain backwards compatibility with 3G firmware throughout.