### PR TITLE
Optionally disable pipeline halt on SIGINT

### DIFF
--- a/core/include/core/G3Pipeline.h
+++ b/core/include/core/G3Pipeline.h
@@ -32,7 +32,7 @@ public:
 
 	// Run the pipeline to completion. If profile is set to true, will print
 	// statistics for each module at completion.
-	void Run(bool profile = false, bool graph = false);
+	void Run(bool profile = false, bool graph = false, bool signal_halt = true);
 
 	// If there is stored graph information get it
 	std::string GetGraphInfo() const {

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -578,17 +578,20 @@ SPT3G_PYTHON_MODULE(core)
 	  "\t  processing if returned by first module. Equivalent to [].\n")
 	    .def("_Add_", &G3Pipeline::Add, bp::arg("name")="")
 	    .def("Run", &G3Pipeline::Run,
-	      (bp::arg("profile")=false, bp::arg("graph")=false), 
+	      (bp::arg("profile")=false, bp::arg("graph")=false,
+	       bp::arg("signal_halt")=true),
 	      "Run pipeline. If profile is True, print execution time "
 	      "statistics for each module when complete. If graph is True, "
 	      "stores control flow data that can be processed with GraphViz "
-	      "once retrieved using GetGraphInfo().")
+	      "once retrieved using GetGraphInfo().  If signal_halt is True "
+	      "(default), the pipeline will stop processing new frames when "
+	      "SIGINT is sent to this process.  Equivalent to what happens when "
+	      "halt_processing() is called.")
 	    .def("GetGraphInfo", &G3Pipeline::GetGraphInfo,
 	      "Get stored control flow information from Run(graph=True)")
 	    .def("halt_processing", &G3Pipeline_halt_processing,
 	      "Halts all running pipelines after they flush all currently "
-	      "in-flight frames. Equivalent to what happens when SIGINT is "
-	      "sent to this process. Once set, the first module will not be "
+	      "in-flight frames. Once set, the first module will not be "
 	      "called again.")
 	    .staticmethod("halt_processing")
 	    .def_readonly("last_frame",


### PR DESCRIPTION
Optional argument `signal_halt` for the `G3Pipeline.Run()` method.  By default, this is set to True to enable current behavior, namely that a pipeline is halted (via the `halt_processing` flag) and terminates after the the current frame reaches the end of the pipeline.  If False, this signal handling is disabled, and it is then up to the user to ensure that a running pipeline is properly halted on interrupt.