### PR TITLE
Optionally ignore wiring information in HousekeepingConsumer

### DIFF
--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -79,9 +79,9 @@ class HousekeepingConsumer(object):
 
     def __call__(self, frame):
 
-        # If a wiring frame has been emitted once already, then process every frame
+        # If boards have been mapped already, then process every frame
         # as received.
-        if self.hwmf is not None or (self.ignore_wiring and len(self.board_serials)):
+        if len(self.board_map):
             return self.ProcessBuffered(frame)
 
         # Otherwise, process at least one Timepoint frame first to gather
@@ -108,7 +108,7 @@ class HousekeepingConsumer(object):
             self.board_serials = [('%04d' % k) for k in frame['DfMux'].keys()]
             return [frame]
 
-        if frame.type == core.G3FrameType.Wiring:
+        if frame.type == core.G3FrameType.Wiring and not self.ignore_wiring:
             core.log_fatal("Received spurious wiring frame.  Do not use "
                            "PyDfMuxHardwareMapInjector with the HousekeepingConsumer.  "
                            "You may update pydfmux to a newer version of pydfmux "

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -79,9 +79,9 @@ class HousekeepingConsumer(object):
 
     def __call__(self, frame):
 
-        # If the boards have been mapped already, then process every frame
+        # If a wiring frame been emitted once already, then process every frame
         # as received.
-        if len(self.board_serials):
+        if self.hwmf is not None or (self.ignore_wiring and len(self.board_serials)):
             return self.ProcessBuffered(frame)
 
         # Otherwise, process at least one Timepoint frame first to gather

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -108,13 +108,23 @@ class HousekeepingConsumer(object):
             self.board_serials = [('%04d' % k) for k in frame['DfMux'].keys()]
             return [frame]
 
-        if frame.type == core.G3FrameType.Wiring and not self.ignore_wiring:
-            core.log_fatal("Received spurious wiring frame.  Do not use "
-                           "PyDfMuxHardwareMapInjector with the HousekeepingConsumer.  "
-                           "You may update pydfmux to a newer version of pydfmux "
-                           "that stores mapped channel names on the boards, and "
-                           "rearrange your data acquisition script.",
-                           unit='HousekeepingConsumer')
+        if frame.type == core.G3FrameType.Wiring:
+            if self.ignore_wiring:
+                core.log_warn(
+                    "Received a wiring frame, which may be inconsistent with "
+                    "board housekeeping data.  Store mapped channel names on the "
+                    "board using updated pydfmux/hidfmux software.",
+                    unit="HousekeepingConsumer",
+                )
+            else:
+                core.log_fatal(
+                    "Received spurious wiring frame.  Do not use "
+                    "PyDfMuxHardwareMapInjector with the HousekeepingConsumer.  "
+                    "You may update pydfmux/hidfmux to a newer version that "
+                    "stores mapped channel names on the boards, and rearrange "
+                    "your data acquisition script.",
+                    unit="HousekeepingConsumer",
+                )
 
         if frame.type == core.G3FrameType.Housekeeping:
             self.map_boards()

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -79,7 +79,7 @@ class HousekeepingConsumer(object):
 
     def __call__(self, frame):
 
-        # If a wiring frame been emitted once already, then process every frame
+        # If a wiring frame has been emitted once already, then process every frame
         # as received.
         if self.hwmf is not None or (self.ignore_wiring and len(self.board_serials)):
             return self.ProcessBuffered(frame)

--- a/dfmux/python/Housekeeping.py
+++ b/dfmux/python/Housekeeping.py
@@ -16,17 +16,19 @@ class HousekeepingConsumer(object):
 
     Also emits a Wiring frame from the housekeeping data.  This requires a
     recent (as of November 2018) version of pydfmux in order to read mapped
-    channel names from each board.
+    channel names from each board.  If ignore_wiring=False, assumes that
+    the wiring map is handled by a separate process.
 
     If collecting real-time data, you may want to set subprocess=True when
     adding this module.
     '''
-    def __init__(self):
+    def __init__(self, ignore_wiring=False):
         self.tuber = {}
         self.board_map = {}
         self.board_serials = []
         self.buffer = []
         self.hwmf = None
+        self.ignore_wiring = ignore_wiring
 
     def map_boards(self):
         '''
@@ -77,9 +79,9 @@ class HousekeepingConsumer(object):
 
     def __call__(self, frame):
 
-        # If a wiring frame has been emitted once already, then process every frame
+        # If the boards have been mapped already, then process every frame
         # as received.
-        if self.hwmf is not None:
+        if len(self.board_serials):
             return self.ProcessBuffered(frame)
 
         # Otherwise, process at least one Timepoint frame first to gather
@@ -135,13 +137,16 @@ class HousekeepingConsumer(object):
                         ismkid = ismkid or "mkid" in boardhk.firmware_name.lower()
                     hkdata[int(boardhk.serial)] = boardhk
 
+                    if self.ignore_wiring:
+                        continue
+
                     ip, crate, slot = self.board_map[board]
                     boardw = self.WiringFromJSON(dat, ip, crate, slot)
                     for key in boardw.keys():
                         hwm[key] = boardw[key]
                         found = True
 
-                if not found:
+                if not found and not self.ignore_wiring:
                     core.log_fatal("No mapped channels found on any IceBoards. "
                                    "You may need to update pydfmux to a newer version of pydfmux "
                                    "that stores mapped channel names on the boards, and reload "
@@ -149,6 +154,9 @@ class HousekeepingConsumer(object):
                                    unit='HousekeepingConsumer')
 
                 frame['DfMuxHousekeeping'] = hkdata
+
+                if self.ignore_wiring:
+                    return [frame]
 
                 hwmf = core.G3Frame(core.G3FrameType.Wiring)
                 hwmf['WiringMap'] = hwm


### PR DESCRIPTION
This enables running the HousekeepingConsumer alongside a Wiring frame generated from a hardware map using the WiringMapInjector.