### PR TITLE
Consistent handling of RA sign

### DIFF
--- a/maps/src/FlatSkyProjection.cxx
+++ b/maps/src/FlatSkyProjection.cxx
@@ -148,10 +148,13 @@ bool FlatSkyProjection::IsCompatible(const FlatSkyProjection & other) const
 			 "(ProjNone) will raise an error.", proj_, other.proj_, ProjNone);
 		return check;
 	}
+	double da = fmod(fabs(alpha0_ - other.alpha0_), 360 * deg);
+	if (da > 180 * deg)
+		da = 360 * deg - da;
 	return (check &&
 		(proj_ == other.proj_) &&
 		(fabs(delta0_ - other.delta0_) < 1e-8) &&
-		(fmod(fabs(alpha0_ - other.alpha0_), 360 * deg) < 1e-8) &&
+		(da < 1e-8) &&
 		(fabs(x0_ - other.x0_) < 1e-8) &&
 		(fabs(y0_ - other.y0_) < 1e-8));
 }
@@ -187,6 +190,8 @@ void FlatSkyProjection::SetProj(MapProjection proj)
 
 void FlatSkyProjection::SetAlphaCenter(double alpha)
 {
+	if (alpha < 0)
+		alpha += 360 * deg;
 	alpha0_ = alpha;
 	q0_ = get_origin_rotator(alpha0_, delta0_);
 }
@@ -307,14 +312,8 @@ FlatSkyProjection::XYToAngle(double x, double y) const
 		break;
 	}
 
-	static const double circ = 360 * deg;
-	static const double halfcirc = 180 * deg;
-	double dalpha = alpha - alpha0_;
-
-	if (dalpha > halfcirc)
-		alpha -= circ;
-	if (dalpha < -halfcirc)
-		alpha += circ;
+	if (alpha < 0)
+		alpha += 360 * deg;
 
 	return {alpha, delta};
 }

--- a/maps/src/HealpixSkyMapInfo.cxx
+++ b/maps/src/HealpixSkyMapInfo.cxx
@@ -273,8 +273,8 @@ HealpixSkyMapInfo::PixelToAngle(size_t pixel) const
 	else
 		pix2ang_ring64(nside_, pixel, &delta, &alpha);
 
-	if (alpha > M_PI)
-		alpha -= twopi;
+	if (alpha < 0)
+		alpha += twopi;
 
 	if (delta < 0 || delta > 180 * G3Units::deg)
 		return {0., 0.};

--- a/maps/src/pointing.cxx
+++ b/maps/src/pointing.cxx
@@ -69,6 +69,8 @@ quat_to_ang(quat q, double &alpha, double &delta)
 	QNORM(q);
 	delta = ASIN(q.R_component_4()) * G3Units::rad;
 	alpha = ATAN2(q.R_component_3(), q.R_component_2())*G3Units::rad;
+	if (alpha < 0)
+		alpha += 360 * deg;
 }
 
 static boost::python::tuple

--- a/maps/src/pointing.cxx
+++ b/maps/src/pointing.cxx
@@ -70,7 +70,7 @@ quat_to_ang(quat q, double &alpha, double &delta)
 	delta = ASIN(q.R_component_4()) * G3Units::rad;
 	alpha = ATAN2(q.R_component_3(), q.R_component_2())*G3Units::rad;
 	if (alpha < 0)
-		alpha += 360 * deg;
+		alpha += 360 * G3Units::deg;
 }
 
 static boost::python::tuple


### PR DESCRIPTION
Ensure that RA angles for G3SkyMap objects are in the range (0, 360 deg).

Also fix a bug in the RA check in flat sky map compatibility.