### PR TITLE
Add a CMake option for adjusting the build for python wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
+option(BUILD_WHEELS "Configure build for python wheels")
+
 # Work around stupid broken Red Hat systems
 set(CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "")
 
@@ -61,6 +63,8 @@ target_compile_options(spt3g INTERFACE -Wno-unknown-warning-option -Wno-unused -
 # Fix bugs in GCC 4.4's strict aliasing code by turning it off
 target_compile_options(spt3g INTERFACE -fno-strict-aliasing)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Boost bits we need
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
@@ -76,7 +80,11 @@ if(Boost_VERSION VERSION_GREATER 1.79)
 endif()
 
 target_include_directories(spt3g INTERFACE ${Boost_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
-target_link_libraries(spt3g INTERFACE pthread ${Boost_LIBRARIES} ${Python_LIBRARIES})
+if(BUILD_WHEELS)
+	target_link_libraries(spt3g INTERFACE pthread ${Boost_LIBRARIES} Python::Module)
+else()
+	target_link_libraries(spt3g INTERFACE pthread ${Boost_LIBRARIES} ${Python_LIBRARIES})
+endif()
 
 # Work around yet more bugs in GCC 4.4, this time with C++ 11 support
 # Also increase maximum number of arguments in python bindings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,10 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "libspt3g-")
 
 # Raise errors on every warning by default
 # (use target-specific options to disable particular warnings)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+if(NOT BUILD_WHEELS)
+	# we should probably just fix all the warnings rather than ignoring them
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+endif()
 
 # Interface library for flags and library dependencies
 add_library(spt3g INTERFACE)

--- a/cmake/Spt3gBoostPython.cmake
+++ b/cmake/Spt3gBoostPython.cmake
@@ -1,6 +1,8 @@
 # Locate Python
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.12)
+if(BUILD_WHEELS)
+	find_package(Python COMPONENTS Interpreter Development.Module)
+elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.12)
 	find_package(Python COMPONENTS Interpreter Development)
 else()
 	find_package(PythonInterp)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,12 +1,15 @@
 # Build a minimal library with a constant name which can be loaded as a python
 # module with a plain `import`, which can then load other modules which are
 # native libraries with normal names.
-add_library(dload SHARED src/dload.c)
-set_target_properties(dload PROPERTIES PREFIX "")
-set_target_properties(dload PROPERTIES SUFFIX ".so")
+if(BUILD_WHEELS)
+	Python_add_library(dload MODULE src/dload.c)
+else()
+	set_target_properties(dload PROPERTIES PREFIX "")
+	set_target_properties(dload PROPERTIES SUFFIX ".so")
+	target_include_directories(dload PRIVATE ${Python_INCLUDE_DIRS})
+	target_link_libraries(dload PUBLIC ${Python_LIBRARIES})
+endif()
 install(TARGETS dload DESTINATION ${PYTHON_MODULE_DIR}/spt3g)
-target_include_directories(dload PRIVATE ${Python_INCLUDE_DIRS})
-target_link_libraries(dload PUBLIC ${Python_LIBRARIES})
 
 # OS X has a broken implementatin of pthreads.
 if(APPLE)
@@ -105,8 +108,10 @@ add_spt3g_test(pipelineinfo)
 add_spt3g_test(quaternions)
 add_spt3g_test(timesample)
 
-add_spt3g_test_program(test
-                       SOURCE_FILES
-                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
-                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
-                       USE_PROJECTS core)
+if(NOT BUILD_WHEELS)
+	add_spt3g_test_program(test
+		SOURCE_FILES
+		${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
+		${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
+		USE_PROJECTS core)
+endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@
 if(BUILD_WHEELS)
 	Python_add_library(dload MODULE src/dload.c)
 else()
+	add_library(dload SHARED src/dload.c)
 	set_target_properties(dload PROPERTIES PREFIX "")
 	set_target_properties(dload PROPERTIES SUFFIX ".so")
 	target_include_directories(dload PRIVATE ${Python_INCLUDE_DIRS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_executable(cppexample cppexample.cxx) 
-target_link_libraries(cppexample core)
+if(NOT BUILD_WHEELS)
+	add_executable(cppexample cppexample.cxx)
+	target_link_libraries(cppexample core)
+endif()


### PR DESCRIPTION
This does not build executables and does not link directly against python libraries.