### PR TITLE
Consolidate IO stream handling in one place

### DIFF
--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/iostreams/filtering_stream.hpp>
+#include <dataio.h>
 
 #include <G3Module.h>
 
@@ -23,7 +23,7 @@ private:
 	bool prefix_file_;
 	std::string cur_file_;
 	std::deque<std::string> filename_;
-	boost::iostreams::filtering_istream stream_;
+	g3_istream stream_;
 	int n_frames_to_read_;
 	int n_frames_read_;
 	int n_frames_cur_;

--- a/core/include/core/G3Writer.h
+++ b/core/include/core/G3Writer.h
@@ -2,7 +2,7 @@
 #define _G3_ARCWRITER_H
 
 #include <string>
-#include <boost/iostreams/filtering_stream.hpp>
+#include <dataio.h>
 
 #include <G3Module.h>
 
@@ -18,7 +18,7 @@ public:
 	void Flush();
 private:
 	std::string filename_;
-	boost::iostreams::filtering_ostream stream_;
+	g3_ostream stream_;
 	std::vector<G3Frame::FrameType> streams_;
 
 	SET_LOGGER("G3Writer");

--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -2,6 +2,7 @@
 #define _G3_DATAIO_H
 
 #include <string>
+#include <vector>
 #include <boost/iostreams/filtering_stream.hpp>
 
 // Function to obtain a filtering istream from a path/URL/someplace
@@ -10,6 +11,31 @@
 
 int g3_istream_from_path(boost::iostreams::filtering_istream &stream,
     const std::string &path, float timeout=-1.0);
+
+// Function to stream data from a char buffer
+
+void g3_istream_from_buffer(boost::iostreams::filtering_istream &stream,
+    const char *buf, size_t len);
+
+// Function to obtain a filtering ostream from a path
+// Knows how to compress files (based on filename extension)
+
+void g3_ostream_to_path(boost::iostreams::filtering_ostream &stream,
+    const std::string &path, bool append=false, bool counter=false);
+
+// Function to return a count of streamed characters
+
+size_t g3_ostream_count(boost::iostreams::filtering_ostream &stream);
+
+// Function to stream data to a char buffer
+
+void g3_ostream_to_buffer(boost::iostreams::filtering_ostream &stream,
+    std::vector<char> &buf);
+
+// Function to check whether the input or output file path is valid
+
+void g3_check_input_path(const std::string &path);
+void g3_check_output_path(const std::string &path);
 
 #endif
 

--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -5,32 +5,36 @@
 #include <vector>
 #include <boost/iostreams/filtering_stream.hpp>
 
+typedef boost::iostreams::filtering_istream g3_istream;
+typedef boost::iostreams::filtering_ostream g3_ostream;
+
 // Function to obtain a filtering istream from a path/URL/someplace
 // Knows how to decompress files if compressed (based on filename extension),
 // read files from disk, and from network sockets
 
-int g3_istream_from_path(boost::iostreams::filtering_istream &stream,
-    const std::string &path, float timeout=-1.0);
+int g3_istream_from_path(g3_istream &stream, const std::string &path,
+    float timeout=-1.0);
+
+off_t g3_istream_seek(g3_istream &stream, off_t offset);
+off_t g3_istream_tell(g3_istream &stream);
 
 // Function to stream data from a char buffer
 
-void g3_istream_from_buffer(boost::iostreams::filtering_istream &stream,
-    const char *buf, size_t len);
+void g3_istream_from_buffer(g3_istream &stream, const char *buf, size_t len);
 
 // Function to obtain a filtering ostream from a path
 // Knows how to compress files (based on filename extension)
 
-void g3_ostream_to_path(boost::iostreams::filtering_ostream &stream,
-    const std::string &path, bool append=false, bool counter=false);
+void g3_ostream_to_path(g3_ostream &stream, const std::string &path,
+    bool append=false, bool counter=false);
 
 // Function to return a count of streamed characters
 
-size_t g3_ostream_count(boost::iostreams::filtering_ostream &stream);
+size_t g3_ostream_count(g3_ostream &stream);
 
 // Function to stream data to a char buffer
 
-void g3_ostream_to_buffer(boost::iostreams::filtering_ostream &stream,
-    std::vector<char> &buf);
+void g3_ostream_to_buffer(g3_ostream &stream, std::vector<char> &buf);
 
 // Function to check whether the input or output file path is valid
 

--- a/core/include/core/serialization.h
+++ b/core/include/core/serialization.h
@@ -1,10 +1,7 @@
 #ifndef _G3_SERIALIZATION_H
 #define _G3_SERIALIZATION_H
 
-#include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/device/array.hpp>
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
+#include <dataio.h>
 
 #include <cereal/archives/portable_binary.hpp>
 
@@ -32,9 +29,8 @@ struct g3frameobject_picklesuite : boost::python::pickle_suite
 	{
 		namespace bp = boost::python;
 		std::vector<char> buffer;
-		boost::iostreams::stream<
-		    boost::iostreams::back_insert_device<std::vector<char> > >
-		    os(buffer);
+		boost::iostreams::filtering_ostream os;
+		g3_ostream_to_buffer(os, buffer);
 		{
 			cereal::PortableBinaryOutputArchive ar(os);
 			ar << bp::extract<const T &>(obj)();
@@ -54,8 +50,8 @@ struct g3frameobject_picklesuite : boost::python::pickle_suite
 		PyObject_GetBuffer(bp::object(state[1]).ptr(), &view,
 		    PyBUF_SIMPLE);
 
-		boost::iostreams::array_source src((char *)view.buf, view.len);
-		boost::iostreams::filtering_istream fis(src);
+		boost::iostreams::filtering_istream fis;
+		g3_istream_from_buffer(fis, (char *)view.buf, view.len);
 		cereal::PortableBinaryInputArchive ar(fis);
 
 		bp::extract<bp::dict>(obj.attr("__dict__"))().update(state[0]);

--- a/core/include/core/serialization.h
+++ b/core/include/core/serialization.h
@@ -29,7 +29,7 @@ struct g3frameobject_picklesuite : boost::python::pickle_suite
 	{
 		namespace bp = boost::python;
 		std::vector<char> buffer;
-		boost::iostreams::filtering_ostream os;
+		g3_ostream os;
 		g3_ostream_to_buffer(os, buffer);
 		{
 			cereal::PortableBinaryOutputArchive ar(os);
@@ -50,7 +50,7 @@ struct g3frameobject_picklesuite : boost::python::pickle_suite
 		PyObject_GetBuffer(bp::object(state[1]).ptr(), &view,
 		    PyBUF_SIMPLE);
 
-		boost::iostreams::filtering_istream fis;
+		g3_istream fis;
 		g3_istream_from_buffer(fis, (char *)view.buf, view.len);
 		cereal::PortableBinaryInputArchive ar(fis);
 

--- a/core/src/G3Frame.cxx
+++ b/core/src/G3Frame.cxx
@@ -390,18 +390,18 @@ void G3Frame::blob_encode(struct blob_container &blob)
 
 	// If no encoded frameobject, serialize it
 	blob.blob = boost::make_shared<std::vector<char> >();
-	boost::iostreams::filtering_ostream item_os;
+	g3_ostream item_os;
 	g3_ostream_to_buffer(item_os, *blob.blob);
 	cereal::PortableBinaryOutputArchive item_ar(item_os);
 	item_ar << make_nvp("val", blob.frameobject);
 	item_os.flush();
 }
 
-template void G3Frame::load(boost::iostreams::filtering_istream &);
+template void G3Frame::load(g3_istream &);
 template void G3Frame::load(std::istream &);
 template void G3Frame::load(std::istringstream &);
 
-template void G3Frame::save(boost::iostreams::filtering_ostream &) const;
+template void G3Frame::save(g3_ostream &) const;
 template void G3Frame::save(std::ostream &) const;
 template void G3Frame::save(std::ostringstream &) const;
 
@@ -431,7 +431,7 @@ struct g3frame_picklesuite : boost::python::pickle_suite
 	{
 		namespace bp = boost::python;
 		std::vector<char> buffer;
-		boost::iostreams::filtering_ostream os;
+		g3_ostream os;
 		g3_ostream_to_buffer(os, buffer);
 		(bp::extract<const G3Frame &>(obj))().save(os);
 		os.flush();

--- a/core/src/G3Frame.cxx
+++ b/core/src/G3Frame.cxx
@@ -2,12 +2,7 @@
 #include <G3Data.h>
 #include <serialization.h>
 #include <pybindings.h>
-
-#include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/device/array.hpp>
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/copy.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
+#include <dataio.h>
 
 #include <sstream>
 #include <stdlib.h>
@@ -395,9 +390,8 @@ void G3Frame::blob_encode(struct blob_container &blob)
 
 	// If no encoded frameobject, serialize it
 	blob.blob = boost::make_shared<std::vector<char> >();
-	boost::iostreams::stream<
-	  boost::iostreams::back_insert_device<std::vector<char> > >
-	  item_os(*blob.blob);
+	boost::iostreams::filtering_ostream item_os;
+	g3_ostream_to_buffer(item_os, *blob.blob);
 	cereal::PortableBinaryOutputArchive item_ar(item_os);
 	item_ar << make_nvp("val", blob.frameobject);
 	item_os.flush();
@@ -437,8 +431,8 @@ struct g3frame_picklesuite : boost::python::pickle_suite
 	{
 		namespace bp = boost::python;
 		std::vector<char> buffer;
-		boost::iostreams::filtering_ostream os(
-		    boost::iostreams::back_inserter(buffer));
+		boost::iostreams::filtering_ostream os;
+		g3_ostream_to_buffer(os, buffer);
 		(bp::extract<const G3Frame &>(obj))().save(os);
 		os.flush();
 

--- a/core/src/G3Map.cxx
+++ b/core/src/G3Map.cxx
@@ -159,7 +159,7 @@ template <class A> void G3MapFrameObject::save(A &ar, const unsigned v) const
 	uint32_t len = size();
 	ar << cereal::make_nvp("len", len);
 
-	boost::iostreams::filtering_ostream os;
+	g3_ostream os;
 	for (auto i = begin(); i != end(); i++) {
 		ar << cereal::make_nvp("key", i->first);
 
@@ -184,7 +184,7 @@ template <class A> void G3MapFrameObject::load(A &ar, const unsigned v)
 
 	uint32_t len;
 	ar >> cereal::make_nvp("len", len);
-	boost::iostreams::filtering_istream fis;
+	g3_istream fis;
 	for (uint32_t i = 0; i < len; i++) {
 		std::pair<std::string, G3FrameObjectPtr> item;
 		std::vector<char> buffer;

--- a/core/src/G3MultiFileWriter.cxx
+++ b/core/src/G3MultiFileWriter.cxx
@@ -24,7 +24,7 @@ private:
 	std::vector<G3Frame::FrameType> always_break_on_;
 	boost::python::object newfile_callback_;
 
-	boost::iostreams::filtering_ostream stream_;
+	g3_ostream stream_;
 	std::vector<G3FramePtr> metadata_cache_;
 	int seqno;
 

--- a/core/src/G3NetworkSender.cxx
+++ b/core/src/G3NetworkSender.cxx
@@ -173,7 +173,7 @@ void G3NetworkSender::SerializeFrame(serialization_task& task)
 {
 	try{
 		netbuf_type buf(new std::vector<char>);
-		boost::iostreams::filtering_ostream os;
+		g3_ostream os;
 		g3_ostream_to_buffer(os, *buf);
 		task.input->save(os);
 		os.flush();

--- a/core/src/G3NetworkSender.cxx
+++ b/core/src/G3NetworkSender.cxx
@@ -1,10 +1,7 @@
 #include <pybindings.h>
 #include <G3NetworkSender.h>
 
-#include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/device/array.hpp>
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
+#include <dataio.h>
 
 #include <chrono>
 
@@ -176,8 +173,8 @@ void G3NetworkSender::SerializeFrame(serialization_task& task)
 {
 	try{
 		netbuf_type buf(new std::vector<char>);
-		boost::iostreams::filtering_ostream os(
-			boost::iostreams::back_inserter(*buf));
+		boost::iostreams::filtering_ostream os;
+		g3_ostream_to_buffer(os, *buf);
 		task.input->save(os);
 		os.flush();
 		task.output.set_value(buf);

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -100,13 +100,15 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 }
 
 off_t G3Reader::Seek(off_t offset) {
-	if (stream_.peek() == EOF && offset != Tell())
+	try {
+		return g3_istream_seek(stream_, offset);
+	} catch (...) {
 		log_fatal("Cannot seek %s; stream closed at EOF.", cur_file_.c_str());
-	return boost::iostreams::seek(stream_, offset, std::ios_base::beg);
+	}
 }
 
 off_t G3Reader::Tell() {
-	return boost::iostreams::seek(stream_, 0, std::ios_base::cur);
+	return g3_istream_tell(stream_);
 }
 
 PYBINDINGS("core") {

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -2,19 +2,13 @@
 #include <dataio.h>
 #include <G3Reader.h>
 
-#include <boost/filesystem.hpp>
-
 G3Reader::G3Reader(std::string filename, int n_frames_to_read,
     float timeout, bool track_filename) :
     prefix_file_(false), n_frames_to_read_(n_frames_to_read),
     n_frames_read_(0), n_frames_cur_(0), timeout_(timeout),
     track_filename_(track_filename)
 {
-	boost::filesystem::path fpath(filename);
-	if (filename.find("://") == std::string::npos &&
-	   (!boost::filesystem::exists(fpath) ||
-	    !boost::filesystem::is_regular_file(fpath)))
-		log_fatal("Could not find file %s", filename.c_str());
+	g3_check_input_path(filename);
 	StartFile(filename);
 }
 
@@ -28,11 +22,7 @@ G3Reader::G3Reader(std::vector<std::string> filename, int n_frames_to_read,
 		log_fatal("Empty file list provided to G3Reader");
 
 	for (auto i = filename.begin(); i != filename.end(); i++){
-		boost::filesystem::path fpath(*i);
-		if (i->find("://") == std::string::npos &&
-		   (!boost::filesystem::exists(fpath) ||
-		    !boost::filesystem::is_regular_file(fpath)))
-			log_fatal("Could not find file %s", i->c_str());
+		g3_check_input_path(*i);
 		filename_.push_back(*i);
 	}
 	StartFile(filename_.front());

--- a/core/src/G3Writer.cxx
+++ b/core/src/G3Writer.cxx
@@ -1,39 +1,14 @@
 #include <pybindings.h>
 #include <G3Writer.h>
-
-#include <boost/algorithm/string.hpp>
-#include <boost/iostreams/device/file.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
-#ifdef BZIP2_FOUND
-#include <boost/iostreams/filter/bzip2.hpp>
-#endif
-#include <boost/filesystem.hpp>
+#include <dataio.h>
 
 G3Writer::G3Writer(std::string filename,
     std::vector<G3Frame::FrameType> streams,
     bool append) :
     filename_(filename), streams_(streams)
 {
-	boost::filesystem::path fpath(filename);
-	if (fpath.empty() || (fpath.has_parent_path() &&
-	    !boost::filesystem::exists(fpath.parent_path())))
-		throw std::runtime_error(std::string("Parent path does not "
-		    "exist: ") + fpath.parent_path().string());
-
-	if (boost::algorithm::ends_with(filename, ".gz") && !append)
-		stream_.push(boost::iostreams::gzip_compressor());
-	if (boost::algorithm::ends_with(filename, ".bz2") && !append) {
-#ifdef BZIP2_FOUND
-		stream_.push(boost::iostreams::bzip2_compressor());
-#else
-		log_fatal("Boost not compiled with bzip2 support.");
-#endif
-	}
-
-	std::ios_base::openmode mode = std::ios::binary;
-	if (append)
-		mode |= std::ios::app;
-	stream_.push(boost::iostreams::file_sink(filename, mode));
+	g3_check_output_path(filename);
+	g3_ostream_to_path(stream_, filename, append);
 }
 
 G3Writer::~G3Writer()

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -2,14 +2,14 @@
 #include <dataio.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #ifdef BZIP2_FOUND
 #include <boost/iostreams/filter/bzip2.hpp>
 #endif
 #include <boost/iostreams/device/file.hpp>
-#include <boost/iostreams/device/mapped_file.hpp>
 #include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/filesystem.hpp>
 
 #include <sys/types.h>
@@ -17,6 +17,8 @@
 #include <netinet/in.h>
 #include <netdb.h>
 #include <stdlib.h>
+
+#include "counter64.hpp"
 
 int
 g3_istream_from_path(boost::iostreams::filtering_istream &stream,
@@ -151,4 +153,77 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 	}
 
 	return fd;
+}
+
+void
+g3_istream_from_buffer(boost::iostreams::filtering_istream &stream,
+    const char *buf, size_t len)
+{
+	stream.reset();
+	stream.push(boost::iostreams::array_source(buf, len));
+}
+
+void
+g3_ostream_to_path(boost::iostreams::filtering_ostream &stream,
+    const std::string &path, bool append, bool counter)
+{
+	stream.reset();
+	if (boost::algorithm::ends_with(path, ".gz") && !append)
+		stream.push(boost::iostreams::gzip_compressor());
+	if (boost::algorithm::ends_with(path, ".bz2") && !append) {
+#ifdef BZIP2_FOUND
+		stream.push(boost::iostreams::bzip2_compressor());
+#else
+		log_fatal("Boost not compiled with bzip2 support.");
+#endif
+	}
+
+	if (counter)
+		stream.push(boost::iostreams::counter64());
+	std::ios_base::openmode mode = std::ios::binary;
+	if (append)
+		mode |= std::ios::app;
+	stream.push(boost::iostreams::file_sink(path, mode));
+}
+
+size_t
+g3_ostream_count(boost::iostreams::filtering_ostream &stream)
+{
+	boost::iostreams::counter64 *counter =
+	    stream.component<boost::iostreams::counter64>(
+	    stream.size() - 2);
+	if (!counter)
+		log_fatal("Could not get stream counter");
+
+	return counter->characters();
+}
+
+void
+g3_ostream_to_buffer(boost::iostreams::filtering_ostream &stream,
+    std::vector<char> &buf)
+{
+	stream.reset();
+	stream.push(boost::iostreams::back_inserter(buf));
+}
+
+void
+g3_check_input_path(const std::string &path)
+{
+	if (path.find("://") == path.npos)
+		return;
+
+	boost::filesystem::path fpath(path);
+	if (!boost::filesystem::exists(fpath) ||
+	    !boost::filesystem::is_regular_file(fpath))
+		log_fatal("Could not find file %s", path.c_str());
+}
+
+void
+g3_check_output_path(const std::string &path)
+{
+	boost::filesystem::path fpath(path);
+	if (fpath.empty() || (fpath.has_parent_path() &&
+	    !boost::filesystem::exists(fpath.parent_path())))
+		log_fatal("Parent path does not exist: %s",
+		    fpath.parent_path().string().c_str());
 }

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -209,7 +209,7 @@ g3_ostream_to_buffer(boost::iostreams::filtering_ostream &stream,
 void
 g3_check_input_path(const std::string &path)
 {
-	if (path.find("://") == path.npos)
+	if (path.find("://") != path.npos)
 		return;
 
 	boost::filesystem::path fpath(path);

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -157,7 +157,7 @@ g3_istream_from_path(g3_istream &stream, const std::string &path, float timeout)
 off_t
 g3_istream_seek(g3_istream &stream, off_t offset)
 {
-	if (stream.peek() == EOF || offset != g3_istream_tell(stream))
+	if (stream.peek() == EOF && offset != g3_istream_tell(stream))
 		log_fatal("Cannot seek stream, closed at EOF.");
 	return boost::iostreams::seek(stream, offset, std::ios_base::beg);
 }

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -21,8 +21,7 @@
 #include "counter64.hpp"
 
 int
-g3_istream_from_path(boost::iostreams::filtering_istream &stream,
-    const std::string &path, float timeout)
+g3_istream_from_path(g3_istream &stream, const std::string &path, float timeout)
 {
 	stream.reset();
 	if (boost::algorithm::ends_with(path, ".gz"))
@@ -155,17 +154,30 @@ g3_istream_from_path(boost::iostreams::filtering_istream &stream,
 	return fd;
 }
 
+off_t
+g3_istream_seek(g3_istream &stream, off_t offset)
+{
+	if (stream.peek() == EOF || offset != g3_istream_tell(stream))
+		log_fatal("Cannot seek stream, closed at EOF.");
+	return boost::iostreams::seek(stream, offset, std::ios_base::beg);
+}
+
+off_t
+g3_istream_tell(g3_istream &stream)
+{
+	return boost::iostreams::seek(stream, 0, std::ios_base::cur);
+}
+
 void
-g3_istream_from_buffer(boost::iostreams::filtering_istream &stream,
-    const char *buf, size_t len)
+g3_istream_from_buffer(g3_istream &stream, const char *buf, size_t len)
 {
 	stream.reset();
 	stream.push(boost::iostreams::array_source(buf, len));
 }
 
 void
-g3_ostream_to_path(boost::iostreams::filtering_ostream &stream,
-    const std::string &path, bool append, bool counter)
+g3_ostream_to_path(g3_ostream &stream, const std::string &path,
+    bool append, bool counter)
 {
 	stream.reset();
 	if (boost::algorithm::ends_with(path, ".gz") && !append)
@@ -187,7 +199,7 @@ g3_ostream_to_path(boost::iostreams::filtering_ostream &stream,
 }
 
 size_t
-g3_ostream_count(boost::iostreams::filtering_ostream &stream)
+g3_ostream_count(g3_ostream &stream)
 {
 	boost::iostreams::counter64 *counter =
 	    stream.component<boost::iostreams::counter64>(
@@ -199,7 +211,7 @@ g3_ostream_count(boost::iostreams::filtering_ostream &stream)
 }
 
 void
-g3_ostream_to_buffer(boost::iostreams::filtering_ostream &stream,
+g3_ostream_to_buffer(g3_ostream &stream,
     std::vector<char> &buf)
 {
 	stream.reset();

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -222,8 +222,14 @@ void
 g3_check_output_path(const std::string &path)
 {
 	boost::filesystem::path fpath(path);
-	if (fpath.empty() || (fpath.has_parent_path() &&
-	    !boost::filesystem::exists(fpath.parent_path())))
+
+	if (fpath.empty())
+		log_fatal("Empty file path");
+
+	if (!fpath.has_parent_path())
+		return;
+
+	if (!boost::filesystem::exists(fpath.parent_path()))
 		log_fatal("Parent path does not exist: %s",
 		    fpath.parent_path().string().c_str());
 }

--- a/gcp/src/ARCFileReader.cxx
+++ b/gcp/src/ARCFileReader.cxx
@@ -9,9 +9,6 @@
 #include <dataio.h>
 #include <gcp/Experiments.h>
 
-#include <boost/iostreams/filtering_stream.hpp>
-#include <boost/filesystem.hpp>
-
 #include <string.h>
 #include <arpa/inet.h>
 
@@ -142,10 +139,7 @@ ARCFileReader::ARCFileReader(const std::string &path,
 		log_fatal("Unrecognized Experiment");
 	}
 
-	boost::filesystem::path fpath(path);
-	if (path.find("://") == path.npos && (!boost::filesystem::exists(fpath) ||
-	    !boost::filesystem::is_regular_file(fpath)))
-		log_fatal("Could not find file %s", path.c_str());
+	g3_check_input_path(path);
 	StartFile(path);
 }
 
@@ -167,10 +161,7 @@ ARCFileReader::ARCFileReader(const std::vector<std::string> &filename,
 		log_fatal("Empty file list provided to G3Reader");
 
 	for (auto i = filename.begin(); i != filename.end(); i++){
-		boost::filesystem::path fpath(*i);
-		if (!boost::filesystem::exists(fpath) ||
-		    !boost::filesystem::is_regular_file(fpath)) 
-			log_fatal("Could not find file %s", i->c_str());
+		g3_check_input_path(*i);
 		filename_.push_back(*i);
 	}
 

--- a/gcp/src/ARCFileReader.cxx
+++ b/gcp/src/ARCFileReader.cxx
@@ -89,7 +89,7 @@ public:
 private:
 	void StartFile(const std::string & path);
 	
-	boost::iostreams::filtering_istream stream_;
+	g3_istream stream_;
 
 	struct block_stats {
 		int flags;


### PR DESCRIPTION
This PR migrates all of the code that handles file and buffer IO stream creation into one place.  This ensures consistent handling of all input and output data serialization streams, and minimizes the footprint of the Boost iostreams and filesystem libraries in the core code, making it incrementally easier to eventually replace Boost altogether.