### PR TITLE
First pass at removing Boost library dependencies

### DIFF
--- a/cmake/G3Test.h
+++ b/cmake/G3Test.h
@@ -10,6 +10,9 @@
 #include <string>
 #include <vector>
 
+#define STRINGIZE(s) STRINGIZE_DIRECT(s)
+#define STRINGIZE_DIRECT(s) #s
+
 namespace G3Test{
 
 class TestFailure{
@@ -88,7 +91,7 @@ inline void testEquivalence(const std::string& file, unsigned int line,
 /// TEST_GROUP(MyTests)
 #define TEST_GROUP(GROUPNAME) \
 namespace{ \
-static const char* GetTestGroup(){ return #GROUPNAME; } \
+static const char* GetTestGroup(){ return STRINGIZE(GROUPNAME); } \
 }
 
 /// Define a test. Use like:
@@ -100,7 +103,7 @@ static const char* GetTestGroup(){ return #GROUPNAME; } \
 static void test_implementation_ ## TESTNAME(); \
 namespace{ \
 static G3Test::TestRegisterer register_ ## TESTNAME (GetTestGroup(), \
-	#TESTNAME, \
+	STRINGIZE(TESTNAME), \
 	test_implementation_ ## TESTNAME); \
 } \
 static void test_implementation_ ## TESTNAME()
@@ -108,7 +111,7 @@ static void test_implementation_ ## TESTNAME()
 /// Require that a predicate must be true, or mark the containing test as
 /// failed. An optional message may be passed after the predicate.
 #define ENSURE(predicate,...) \
-G3Test::testAssertion(__FILE__, __LINE__, #predicate, (predicate), ##__VA_ARGS__);
+G3Test::testAssertion(__FILE__, __LINE__, STRINGIZE(predicate), (predicate), ##__VA_ARGS__);
 
 /// Unconditionally mark the containing test as failed. A message may
 /// optionally be passed.
@@ -126,7 +129,7 @@ G3Test::testAssertion(__FILE__, __LINE__, "FAILURE", false, ##__VA_ARGS__);
 /// left and right operands and their values are printed in the event of a
 /// failure.
 #define ENSURE_EQUAL(left,right,...) \
-G3Test::testEquivalence(__FILE__, __LINE__, left, right, #left, #right, ##__VA_ARGS__);
+G3Test::testEquivalence(__FILE__, __LINE__, left, right, STRINGIZE(left), STRINGIZE(right), ##__VA_ARGS__);
 
 
 //=============================================================================

--- a/cmake/G3Test.h
+++ b/cmake/G3Test.h
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <boost/preprocessor/stringize.hpp>
 
 namespace G3Test{
 
@@ -89,7 +88,7 @@ inline void testEquivalence(const std::string& file, unsigned int line,
 /// TEST_GROUP(MyTests)
 #define TEST_GROUP(GROUPNAME) \
 namespace{ \
-static const char* GetTestGroup(){ return BOOST_PP_STRINGIZE(GROUPNAME); } \
+static const char* GetTestGroup(){ return #GROUPNAME; } \
 }
 
 /// Define a test. Use like:
@@ -101,7 +100,7 @@ static const char* GetTestGroup(){ return BOOST_PP_STRINGIZE(GROUPNAME); } \
 static void test_implementation_ ## TESTNAME(); \
 namespace{ \
 static G3Test::TestRegisterer register_ ## TESTNAME (GetTestGroup(), \
-	BOOST_PP_STRINGIZE(TESTNAME), \
+	#TESTNAME, \
 	test_implementation_ ## TESTNAME); \
 } \
 static void test_implementation_ ## TESTNAME()
@@ -109,7 +108,7 @@ static void test_implementation_ ## TESTNAME()
 /// Require that a predicate must be true, or mark the containing test as
 /// failed. An optional message may be passed after the predicate.
 #define ENSURE(predicate,...) \
-G3Test::testAssertion(__FILE__, __LINE__, BOOST_PP_STRINGIZE(predicate), (predicate), ##__VA_ARGS__);
+G3Test::testAssertion(__FILE__, __LINE__, #predicate, (predicate), ##__VA_ARGS__);
 
 /// Unconditionally mark the containing test as failed. A message may
 /// optionally be passed.
@@ -127,7 +126,7 @@ G3Test::testAssertion(__FILE__, __LINE__, "FAILURE", false, ##__VA_ARGS__);
 /// left and right operands and their values are printed in the event of a
 /// failure.
 #define ENSURE_EQUAL(left,right,...) \
-G3Test::testEquivalence(__FILE__, __LINE__, left, right, BOOST_PP_STRINGIZE(left), BOOST_PP_STRINGIZE(right), ##__VA_ARGS__);
+G3Test::testEquivalence(__FILE__, __LINE__, left, right, #left, #right, ##__VA_ARGS__);
 
 
 //=============================================================================

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,7 +14,7 @@ add_spt3g_library(core SHARED
 	src/G3TriggeredBuilder.cxx src/G3MultiFileWriter.cxx src/dataio.cxx
 	src/crc32.c ${CORE_EXTRA_SRCS}
 	src/G3NetworkSender.cxx src/G3SyslogLogger.cxx
-	src/G3PipelineInfo.cxx src/G3Quat.cxx
+	src/G3PipelineInfo.cxx src/G3Quat.cxx src/G3Units.cxx
 	src/int_storage.cxx src/pybindings.cxx
 )
 

--- a/core/include/core/pybindings.h
+++ b/core/include/core/pybindings.h
@@ -175,6 +175,9 @@ public:
 #define SPT3G_PYTHON_MODULE(name) \
 BOOST_PYTHON_MODULE(_lib ## name)
 
+// Create a namespace (importable sub-module) within some parent scope
+bp::object export_namespace(bp::object scope, std::string name);
+
 // Python runtime context to simplify acquiring or releasing the GIL as necessary.
 // To use, simply construct the context object where necessary, e.g.
 //    G3PythonContext ctx("mycontext", false);

--- a/core/include/core/pybindings.h
+++ b/core/include/core/pybindings.h
@@ -5,7 +5,6 @@
 #include <G3Frame.h>
 #include <G3Logging.h>
 
-#include <boost/preprocessor/cat.hpp>
 #include <boost/python.hpp>
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -174,7 +173,7 @@ public:
 //     SPT3G_PYTHON_MODULE(foo)
 // for a package whose name will be _libfoo
 #define SPT3G_PYTHON_MODULE(name) \
-BOOST_PYTHON_MODULE(BOOST_PP_CAT(_lib, name))
+BOOST_PYTHON_MODULE(_lib ## name)
 
 // Python runtime context to simplify acquiring or releasing the GIL as necessary.
 // To use, simply construct the context object where necessary, e.g.

--- a/core/src/G3Units.cxx
+++ b/core/src/G3Units.cxx
@@ -1,0 +1,187 @@
+#include <pybindings.h>
+#include <G3Constants.h>
+
+namespace bp = boost::python;
+
+PYBINDINGS("core") {
+	bp::object umod = export_namespace(bp::scope(), "G3Units");
+#define G3_UNITS_DEF(T) \
+	umod.attr(#T) = G3Units::T
+
+	/* Time */
+	G3_UNITS_DEF(nanosecond);
+	G3_UNITS_DEF(ns);
+	G3_UNITS_DEF(nanoseconds);
+	G3_UNITS_DEF(microsecond);
+	G3_UNITS_DEF(microseconds);
+	G3_UNITS_DEF(us);
+	G3_UNITS_DEF(millisecond);
+	G3_UNITS_DEF(milliseconds);
+	G3_UNITS_DEF(ms);
+	G3_UNITS_DEF(second);
+	G3_UNITS_DEF(seconds);
+	G3_UNITS_DEF(sec);
+	G3_UNITS_DEF(s);
+	G3_UNITS_DEF(minute);
+	G3_UNITS_DEF(minutes);
+	G3_UNITS_DEF(min);
+	G3_UNITS_DEF(hour);
+	G3_UNITS_DEF(hours);
+	G3_UNITS_DEF(h);
+	G3_UNITS_DEF(day);
+	G3_UNITS_DEF(days);
+	G3_UNITS_DEF(rel);
+
+	/* Frequency */
+	G3_UNITS_DEF(Hz);
+	G3_UNITS_DEF(hz);
+	G3_UNITS_DEF(kHz);
+	G3_UNITS_DEF(MHz);
+	G3_UNITS_DEF(GHz);
+
+	/* Angle */
+	G3_UNITS_DEF(rad);
+	G3_UNITS_DEF(radian);
+	G3_UNITS_DEF(radians);
+	G3_UNITS_DEF(deg);
+	G3_UNITS_DEF(degree);
+	G3_UNITS_DEF(degrees);
+	G3_UNITS_DEF(arcmin);
+	G3_UNITS_DEF(arcsec);
+	G3_UNITS_DEF(rahour);
+	G3_UNITS_DEF(raminute);
+	G3_UNITS_DEF(rasecond);
+	G3_UNITS_DEF(rahr);
+
+	/* Length */
+	G3_UNITS_DEF(meter);
+	G3_UNITS_DEF(m);
+	G3_UNITS_DEF(meters);
+	G3_UNITS_DEF(centimeter);
+	G3_UNITS_DEF(cm);
+	G3_UNITS_DEF(millimeter);
+	G3_UNITS_DEF(mm);
+	G3_UNITS_DEF(micron);
+	G3_UNITS_DEF(nanometer);
+	G3_UNITS_DEF(nm);
+	G3_UNITS_DEF(kilometer);
+	G3_UNITS_DEF(km);
+	G3_UNITS_DEF(au);
+	G3_UNITS_DEF(AU);
+	G3_UNITS_DEF(parsec);
+	G3_UNITS_DEF(pc);
+	G3_UNITS_DEF(inch);
+	G3_UNITS_DEF(in);
+	G3_UNITS_DEF(foot);
+	G3_UNITS_DEF(ft);
+
+	/* Power */
+	G3_UNITS_DEF(watt);
+	G3_UNITS_DEF(W);
+	G3_UNITS_DEF(milliwatt);
+	G3_UNITS_DEF(mW);
+	G3_UNITS_DEF(microwatt);
+	G3_UNITS_DEF(uW);
+	G3_UNITS_DEF(nanowatt);
+	G3_UNITS_DEF(nW);
+	G3_UNITS_DEF(picowatt);
+	G3_UNITS_DEF(pW);
+	G3_UNITS_DEF(attowatt);
+	G3_UNITS_DEF(aW);
+	G3_UNITS_DEF(horsepower);
+	G3_UNITS_DEF(hp);
+
+	/* Flux density */
+	G3_UNITS_DEF(jansky);
+	G3_UNITS_DEF(Jy);
+	G3_UNITS_DEF(millijansky);
+	G3_UNITS_DEF(mJy);
+	G3_UNITS_DEF(megajansky);
+	G3_UNITS_DEF(MJy);
+
+	/* Solid angle */
+	G3_UNITS_DEF(sr);
+	G3_UNITS_DEF(steradian);
+	G3_UNITS_DEF(steradians);
+	G3_UNITS_DEF(deg2);
+	G3_UNITS_DEF(sqdeg);
+	G3_UNITS_DEF(squaredegree);
+	G3_UNITS_DEF(squaredegrees);
+	G3_UNITS_DEF(arcmin2);
+	G3_UNITS_DEF(sqarcmin);
+	G3_UNITS_DEF(squarearcmin);
+
+	/* Voltage */
+	G3_UNITS_DEF(volt);
+	G3_UNITS_DEF(V);
+	G3_UNITS_DEF(millivolt);
+	G3_UNITS_DEF(mV);
+	G3_UNITS_DEF(microvolt);
+	G3_UNITS_DEF(uV);
+
+	/* Current */
+	G3_UNITS_DEF(ampere);
+	G3_UNITS_DEF(amp);
+	G3_UNITS_DEF(A);
+	G3_UNITS_DEF(milliamp);
+	G3_UNITS_DEF(mA);
+	G3_UNITS_DEF(microamp);
+	G3_UNITS_DEF(uA);
+	G3_UNITS_DEF(nanoamp);
+	G3_UNITS_DEF(nA);
+
+	/* Temperature */
+	G3_UNITS_DEF(snausage);
+	G3_UNITS_DEF(kelvin);
+	G3_UNITS_DEF(K);
+	G3_UNITS_DEF(millikelvin);
+	G3_UNITS_DEF(mK);
+	G3_UNITS_DEF(microkelvin);
+	G3_UNITS_DEF(uK);
+	G3_UNITS_DEF(nanokelvin);
+	G3_UNITS_DEF(nK);
+	G3_UNITS_DEF(picokelvin);
+	G3_UNITS_DEF(pK);
+	G3_UNITS_DEF(rankine);
+	G3_UNITS_DEF(R);
+
+	/* Pressure */
+	G3_UNITS_DEF(bar);
+	G3_UNITS_DEF(b);
+	G3_UNITS_DEF(millibar);
+	G3_UNITS_DEF(mb);
+	G3_UNITS_DEF(Pa);
+	G3_UNITS_DEF(kPa);
+
+	/* File size */
+	G3_UNITS_DEF(byte);
+	G3_UNITS_DEF(B);
+	G3_UNITS_DEF(bit);
+	G3_UNITS_DEF(kilobyte);
+	G3_UNITS_DEF(KB);
+	G3_UNITS_DEF(megabyte);
+	G3_UNITS_DEF(MB);
+	G3_UNITS_DEF(gigabyte);
+	G3_UNITS_DEF(GB);
+
+	/* Mass */
+	G3_UNITS_DEF(gram);
+	G3_UNITS_DEF(g);
+	G3_UNITS_DEF(kilogram);
+	G3_UNITS_DEF(kg);
+	G3_UNITS_DEF(milligram);
+	G3_UNITS_DEF(mg);
+
+	bp::object cmod = export_namespace(bp::scope(), "G3Constants");
+#define G3_CONSTANTS_DEF(T) \
+	cmod.attr(#T) = G3Constants::T
+
+	G3_CONSTANTS_DEF(c);
+	G3_CONSTANTS_DEF(h);
+	G3_CONSTANTS_DEF(hbar);
+	G3_CONSTANTS_DEF(k);
+	G3_CONSTANTS_DEF(kb);
+	G3_CONSTANTS_DEF(G);
+	G3_CONSTANTS_DEF(g0);
+	G3_CONSTANTS_DEF(e);
+}

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -1,7 +1,6 @@
 #include <G3Logging.h>
 #include <dataio.h>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #ifdef BZIP2_FOUND
 #include <boost/iostreams/filter/bzip2.hpp>
@@ -24,9 +23,9 @@ int
 g3_istream_from_path(g3_istream &stream, const std::string &path, float timeout)
 {
 	stream.reset();
-	if (boost::algorithm::ends_with(path, ".gz"))
+	if (!path.compare(path.size() - 3, 3, ".gz"))
 		stream.push(boost::iostreams::gzip_decompressor());
-	if (boost::algorithm::ends_with(path, ".bz2")) {
+	if (!path.compare(path.size() - 4, 4, ".bz2")) {
 #ifdef BZIP2_FOUND
 		stream.push(boost::iostreams::bzip2_decompressor());
 #else
@@ -180,9 +179,9 @@ g3_ostream_to_path(g3_ostream &stream, const std::string &path,
     bool append, bool counter)
 {
 	stream.reset();
-	if (boost::algorithm::ends_with(path, ".gz") && !append)
+	if (!path.compare(path.size() - 3, 3, ".gz") && !append)
 		stream.push(boost::iostreams::gzip_compressor());
-	if (boost::algorithm::ends_with(path, ".bz2") && !append) {
+	if (!path.compare(path.size() - 4, 4, ".bz2") && !append) {
 #ifdef BZIP2_FOUND
 		stream.push(boost::iostreams::bzip2_compressor());
 #else

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -23,9 +23,9 @@ int
 g3_istream_from_path(g3_istream &stream, const std::string &path, float timeout)
 {
 	stream.reset();
-	if (!path.compare(path.size() - 3, 3, ".gz"))
+	if (path.size() > 3 && !path.compare(path.size() - 3, 3, ".gz"))
 		stream.push(boost::iostreams::gzip_decompressor());
-	if (!path.compare(path.size() - 4, 4, ".bz2")) {
+	if (path.size() > 4 && !path.compare(path.size() - 4, 4, ".bz2")) {
 #ifdef BZIP2_FOUND
 		stream.push(boost::iostreams::bzip2_decompressor());
 #else
@@ -179,9 +179,9 @@ g3_ostream_to_path(g3_ostream &stream, const std::string &path,
     bool append, bool counter)
 {
 	stream.reset();
-	if (!path.compare(path.size() - 3, 3, ".gz") && !append)
+	if (path.size() > 3 && !path.compare(path.size() - 3, 3, ".gz") && !append)
 		stream.push(boost::iostreams::gzip_compressor());
-	if (!path.compare(path.size() - 4, 4, ".bz2") && !append) {
+	if (path.size() > 4 && !path.compare(path.size() - 4, 4, ".bz2") && !append) {
 #ifdef BZIP2_FOUND
 		stream.push(boost::iostreams::bzip2_compressor());
 #else

--- a/core/src/pybindings.cxx
+++ b/core/src/pybindings.cxx
@@ -2,6 +2,16 @@
 
 namespace bp = boost::python;
 
+// Create a namespace (importable sub-module) within some parent scope
+bp::object
+export_namespace(bp::object scope, std::string name)
+{
+	std::string modname = bp::extract<std::string>(scope.attr("__name__") + "." + name);
+	bp::object mod(bp::handle<>(bp::borrowed(PyImport_AddModule(modname.c_str()))));
+	scope.attr(name.c_str()) = mod;
+	return mod;
+}
+
 // The following implements the headerless module registration code
 typedef std::map<std::string, std::vector<void (*)()> > module_reg_t;
 static module_reg_t *modregs = NULL;

--- a/core/src/python.cxx
+++ b/core/src/python.cxx
@@ -1,78 +1,10 @@
 #include <pybindings.h>
 
-#include <boost/python.hpp>
-#include <boost/preprocessor.hpp>
-
-#include <G3Constants.h>
-
 namespace bp = boost::python;
-
-#define UNITS (nanosecond)(ns)(microsecond)(us)(millisecond)(ms) \
-    (second)(sec)(s)(minute)(min)(hour)(h)(day)                    \
-    (nanoseconds)(microseconds)(milliseconds)(seconds)(minutes)\
-    (hours)(days)(rel)\
-    \
-    (Hz)(hz)(MHz)(GHz)(kHz) \
-    \
-    (rad)(radian)(radians)(deg)(degree)(degrees)(arcmin)(arcsec)(rahour)(rahr) \
-    (raminute)(rasecond)\
-    \
-    (meter)(m)(meters)(centimeter)(cm)(millimeter)(mm)(micron)(nanometer)(nm) \
-    (kilometer)(km)(au)(AU)(parsec)(pc)(inch)(in)(foot)(ft)		\
-    \
-    (watt)(W)(milliwatt)(mW)(microwatt)(uW)(nanowatt)(nW)(picowatt)(pW) \
-    (attowatt)(aW)(horsepower)(hp) \
-    \
-    (sr)(steradian)(steradians)(deg2)(sqdeg)(squaredegree)(squaredegrees) \
-    (arcmin2)(sqarcmin)(squarearcmin) \
-    \
-    (jansky)(Jy)(millijansky)(mJy)(megajansky)(MJy) \
-    \
-    (volt)(V)(millivolt)(mV)(microvolt)(uV) \
-    \
-    (ampere)(amp)(A)(milliamp)(mA)(microamp)(uA)(nanoamp)(nA) \
-    \
-    (kelvin)(K)(millikelvin)(mK)(microkelvin)(uK)(nanokelvin)(nK) \
-    (picokelvin)(pK)(rankine)(R)(snausage) \
-    \
-    (bar)(b)(millibar)(mb)(Pa)(kPa) \
-    (byte)(B)(bit)(kilobyte)(KB)(megabyte)(MB)(gigabyte)(GB) \
-    (gram)(g)(kilogram)(kg)(milligram)(mg)
-
-#define UNITS_INTERFACE(r,data,T) \
-  static double BOOST_PP_CAT(g3units_return_,T)() { return G3Units::T; }
-BOOST_PP_SEQ_FOR_EACH(UNITS_INTERFACE,~,UNITS)
-#define G3_UNITS_DEF(r,data,T) \
-  .add_static_property(BOOST_PP_STRINGIZE(T), &BOOST_PP_CAT(g3units_return_, T))
-struct __XXX_fake_g3units_namespace_XXX {};
-
-#define CONSTANTS (c)(h)(hbar)(k)(kb)(G)(g0)(e)
-
-#define CONSTANTS_INTERFACE(r,data,T) \
-  static double BOOST_PP_CAT(g3constants_return_,T)() { return G3Constants::T; }
-BOOST_PP_SEQ_FOR_EACH(CONSTANTS_INTERFACE,~,CONSTANTS)
-#define G3_CONSTANTS_DEF(r,data,T) \
-  .add_static_property(BOOST_PP_STRINGIZE(T), &BOOST_PP_CAT(g3constants_return_, T))
-struct __XXX_fake_g3constants_namespace_XXX {};
 
 SPT3G_PYTHON_MODULE(core)
 {
 	bp::docstring_options docopts(true, true, false);
-
-	// Units values
-	bp::class_<__XXX_fake_g3units_namespace_XXX, boost::noncopyable>(
-	  "G3Units",
-	    "Units suffixes. If you use these, you don't have to worry about "
-	    "units arguments to functions. 1 second is 1*G3Units.s.",
-	    bp::no_init)
-	      BOOST_PP_SEQ_FOR_EACH(G3_UNITS_DEF,~,UNITS);
-
-	// Constants values
-	bp::class_<__XXX_fake_g3constants_namespace_XXX, boost::noncopyable>(
-	  "G3Constants",
-	    "Mathematical and physical constants in G3Units.",
-	    bp::no_init)
-	      BOOST_PP_SEQ_FOR_EACH(G3_CONSTANTS_DEF,~,CONSTANTS);
 
 	// Do everything else
 	G3ModuleRegistrator::CallRegistrarsFor("core");

--- a/gcp/src/GCPMuxDataDecoder.cxx
+++ b/gcp/src/GCPMuxDataDecoder.cxx
@@ -10,7 +10,6 @@
 #include <dfmux/DfMuxSample.h>
 #include <dfmux/DfMuxBuilder.h>
 
-#include <boost/tokenizer.hpp>
 #include <arpa/inet.h>
 
 // Construct a fake board IP 192.168.1.X. This is used for internal
@@ -160,11 +159,12 @@ GCPMuxDataDecoder::EmitWiringMap(G3FramePtr input)
 			continue;
 		}
 
-		boost::char_separator<char> sep("_");
-		boost::tokenizer<boost::char_separator<char> > tok(
-		    channel_path, sep);
-		for (auto j = tok.begin(); j != tok.end(); j++)
-			channel_parts.push_back(atoi(j->c_str()));
+		size_t pos;
+		while ((pos = channel_path.find("_")) != std::string::npos) {
+			std::string tok = channel_path.substr(0, pos);
+			channel_parts.push_back(atoi(tok.c_str()));
+			channel_path.erase(0, pos + 1);
+		}
 
 		// Assign to structure. GCP channel IDs are 1-indexed. 3G's are
 		// 0-indexed, so shift by 1.


### PR DESCRIPTION
This PR replaces various Boost utilities with standard library equivalents where possible.  The changes here are all the pieces that have straightforward replacements.  Remaining uses outside of this PR:

* `boost::math::quaternion`: Replaced with a native G3FrameObject implementation in a separate PR (see #166)
* `boost::filesystem`: Can be easily replaced with `std::filesystem`, but requires C++17.
* `boost::iostreams`:  Intertwined with serialization and python bindings, but the implementation is now entirely contained in core/dataio.cxx/h (see #164)
* `boost::python`:  Yes.