### PR TITLE
Replace boost::filesystem with std:filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{SITE_CMAKE_DIR} "${CMAKE_SOURCE_
 # Work around stupid broken Red Hat systems
 set(CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "")
 
-# Require C++ 14
-set(CMAKE_CXX_STANDARD 14)
+# Require C++ 17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -52,7 +52,7 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 set(Boost_PYTHON_VERSION ${Python_VERSION})
-find_package(Boost COMPONENTS system iostreams filesystem python REQUIRED)
+find_package(Boost COMPONENTS iostreams python REQUIRED)
 
 # Interface library for flags and library dependencies
 add_library(spt3g INTERFACE)

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -9,7 +9,7 @@
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -223,16 +223,16 @@ g3_check_input_path(const std::string &path)
 	if (path.find("://") != path.npos)
 		return;
 
-	boost::filesystem::path fpath(path);
-	if (!boost::filesystem::exists(fpath) ||
-	    !boost::filesystem::is_regular_file(fpath))
+	std::filesystem::path fpath(path);
+	if (!std::filesystem::exists(fpath) ||
+	    !std::filesystem::is_regular_file(fpath))
 		log_fatal("Could not find file %s", path.c_str());
 }
 
 void
 g3_check_output_path(const std::string &path)
 {
-	boost::filesystem::path fpath(path);
+	std::filesystem::path fpath(path);
 
 	if (fpath.empty())
 		log_fatal("Empty file path");
@@ -240,7 +240,7 @@ g3_check_output_path(const std::string &path)
 	if (!fpath.has_parent_path())
 		return;
 
-	if (!boost::filesystem::exists(fpath.parent_path()))
+	if (!std::filesystem::exists(fpath.parent_path()))
 		log_fatal("Parent path does not exist: %s",
 		    fpath.parent_path().string().c_str());
 }

--- a/deps/install_boost.sh
+++ b/deps/install_boost.sh
@@ -35,7 +35,7 @@ if [ ! -e b2 ]; then
         --prefix=${PREFIX} \
         --with-python=$(which python3) \
         --with-python-root=$(python3-config --prefix) \
-        --with-libraries="system,iostreams,filesystem,python,regex"
+        --with-libraries="iostreams,python,regex"
 fi
 
 echo "Building boost..."


### PR DESCRIPTION
With the update to the C++17 standard in #168, we can also drop the `boost::filesystem` dependency.