### PR TITLE
Efficiently reproject partial sky maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ doc/module-autodocs.rst
 doc/moddoc_*
 *.g3
 .DS_Store
+.idea/

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -873,7 +873,7 @@ class ReprojectMaps(object):
         reprojection.  Otherwise, reproject maps without checking the weights.
     partial :  bool=False
         If True, the reproj will be performed on a partial map (of the output map),
-        defined by the mask. If the mask is not provided, it will be detrmined from
+        defined by the mask. If the mask is not provided, it will be determined from
         the non-zero pixels of the first reprojected map.
     mask : G3SkyMapMask, G3SkyMap, or np.ndarray, Optional.
         Mask to be used for partial reproject. This should be of the same size as the output map.

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -880,7 +880,8 @@ class ReprojectMaps(object):
         For numpy array, all zeros/inf/nan/hp.UNSEEN pixels are skipped.
     """
 
-    def __init__(self, map_stub=None, rebin=1, interp=False, weighted=True, partial=False, mask=None):
+    def __init__(self, map_stub=None, rebin=1, interp=False, weighted=True,
+                 partial=False, mask=None):
         assert map_stub is not None, "map_stub argument required"
         self.stub = map_stub.clone(False)
         self.stub.pol_type = None
@@ -916,13 +917,15 @@ class ReprojectMaps(object):
 
             if key in "TQUH":
                 mnew = self.stub.clone(False)
-                maps.reproj_map(m, mnew, rebin=self.rebin, interp=self.interp, mask=self.mask)
+                maps.reproj_map(m, mnew, rebin=self.rebin, interp=self.interp,
+                                mask=self.mask)
 
             elif key in ["Wpol", "Wunpol"]:
                 mnew = maps.G3SkyMapWeights(self.stub)
                 for wkey in mnew.keys():
                     maps.reproj_map(
-                        m[wkey], mnew[wkey], rebin=self.rebin, interp=self.interp, mask=self.mask
+                        m[wkey], mnew[wkey], rebin=self.rebin, interp=self.interp,
+                        mask=self.mask
                     )
 
             frame[key] = mnew
@@ -941,7 +944,8 @@ class ReprojectMaps(object):
             if isinstance(mask, maps.G3SkyMapMask):
                 self._mask = mask
             elif isinstance(mask, maps.G3SkyMap):
-                self._mask = maps.G3SkyMapMask(mask, use_data=True, zero_nans=True, zero_infs=True)
+                self._mask = maps.G3SkyMapMask(mask, use_data=True, zero_nans=True,
+                                               zero_infs=True)
             elif isinstance(mask, np.ndarray):
                 from healpy import UNSEEN
                 tmp = self.stub.clone(False)
@@ -956,4 +960,5 @@ class ReprojectMaps(object):
                 tmp[:] = mask_copy
                 self._mask = maps.G3SkyMapMask(tmp, use_data=True)
             else:
-                raise TypeError("Mask must be a G3SkyMapMask, G3SkyMap, or numpy array")
+                raise TypeError("Mask must be a G3SkyMapMask, G3SkyMap, "
+                                "or numpy array")

--- a/maps/python/map_modules.py
+++ b/maps/python/map_modules.py
@@ -876,8 +876,8 @@ class ReprojectMaps(object):
         defined by the mask. If the mask is not provided, it will be determined from
         the non-zero pixels of the first reprojected map.
     mask : G3SkyMapMask, G3SkyMap, or np.ndarray, Optional.
-        Mask to be used for partial reproject. This should be of the same size as the output map.
-        For numpy array, all zeros/inf/nan/hp.UNSEEN pixels are skipped.
+        Mask to be used for partial reproject. This should be of the same size as the
+        output map. For numpy array, all zeros/inf/nan/hp.UNSEEN pixels are skipped.
     """
 
     def __init__(self, map_stub=None, rebin=1, interp=False, weighted=True,

--- a/maps/src/maputils.cxx
+++ b/maps/src/maputils.cxx
@@ -582,7 +582,8 @@ PYBINDINGS("maps")
 		"the appropriate rotation to the Q and u elements of the associated weights.");
 
 	bp::def("reproj_map", ReprojMap,
-		(bp::arg("in_map"), bp::arg("out_map"), bp::arg("rebin")=1, bp::arg("interp")=false),
+		(bp::arg("in_map"), bp::arg("out_map"), bp::arg("rebin")=1, bp::arg("interp")=false,
+		bp::arg("mask")=bp::object()),
 		"Reprojects the data from in_map onto out_map.  out_map can have a different "
 		"projection, size, resolution, etc.  Optionally account for sub-pixel "
 		"structure by setting rebin > 1 and/or enable bilinear interpolation of "
@@ -590,7 +591,8 @@ PYBINDINGS("maps")
 		"attributes to rotate between Equatorial and Galactic coordinate systems.  "
 		"Use the maps' pol_conv attributes to switch between COSMO and IAU "
 		"polarization conventions.  If output attributes are not set, they will be "
-		"copied from the input map.");
+		"copied from the input map. out_map_mask, if given, skip the unused pixels"
+		"and set these pixels to 0.");
 
 	bp::def("get_map_moments", GetMapMoments,
 		(bp::arg("map"), bp::arg("mask")=G3SkyMapMaskConstPtr(), bp::arg("order")=2,


### PR DESCRIPTION
- option to skip map pixels in ``ReprojectMaps``

For the typical 3% fsky map -> healpix operation, this is 75% faster (the rest is bound by memory write).