### PR TITLE
In macos tests, update python version.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,13 +38,13 @@ jobs:
       if: runner.environment == 'github-hosted' && runner.os == 'macOS'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install macOS Dependencies
       if: runner.environment == 'github-hosted' && runner.os == 'macOS'
       run: |
         brew install --overwrite bzip2 boost boost-python3 flac netcdf
-        python3.12 -m pip install numpy scipy matplotlib astropy healpy sphinx --break-system-packages
+        python3.13 -m pip install numpy scipy matplotlib astropy healpy sphinx --break-system-packages
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory


### PR DESCRIPTION
The homebrew packages for boost-python have been updated to python-3.13.  This trivial changes just uses that python version to match what is used by the homebrew packages.