### PR TITLE
Better G3Reader.tell() method

### DIFF
--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -11,10 +11,10 @@ class G3Reader : public G3Module {
 public:
 	G3Reader(std::string filename, int n_frames_to_read = -1,
                  float timeout = -1., bool track_filename = false,
-	         size_t buffersize = 1024*1024);
+	         size_t buffersize = 1024*1024, bool counter = false);
 	G3Reader(std::vector<std::string> filenames, int n_frames_to_read = -1,
                  float timeout = -1., bool track_filename = false,
-	         size_t buffersize = 1024*1024);
+	         size_t buffersize = 1024*1024, bool counter = false);
 
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
 	off_t Seek(off_t offset);
@@ -32,6 +32,7 @@ private:
 	float timeout_;
 	bool track_filename_;
 	size_t buffersize_;
+	bool counter_;
 
 	SET_LOGGER("G3Reader");
 };

--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -25,10 +25,12 @@ typedef boost::iostreams::filtering_ostream g3_ostream;
  *                  read until EOF.
  * @param  timeout  Timeout in seconds for socket connections.
  * @param  buffersize Advisory buffer size in bytes for aggregating reads
+ * @param  counter  If true, add a counter to the stream configuration,
+ *                  for use by the g3_istream_tell function.
  * @return File descriptor for socket connections, or -1 for file input.
  */
 int g3_istream_from_path(g3_istream &stream, const std::string &path,
-    float timeout=-1.0, size_t buffersize=1024*1024);
+    float timeout=-1.0, size_t buffersize=1024*1024, bool counter=false);
 
 /**
  * Seek to a byte offset in an open input file stream.

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -102,12 +102,9 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 }
 
 off_t G3Reader::Seek(off_t offset) {
+	if (!counter_)
+		log_fatal("Cannot seek %s; stream opened without counter.", cur_file_.c_str());
 	return g3_istream_seek(stream_, offset);
-	// try {
-	// 	return g3_istream_seek(stream_, offset);
-	// } catch (...) {
-	// 	log_fatal("Cannot seek %s; stream closed at EOF.", cur_file_.c_str());
-	// }
 }
 
 off_t G3Reader::Tell() {

--- a/core/src/counter64.hpp
+++ b/core/src/counter64.hpp
@@ -37,7 +37,7 @@ public:
     typedef Ch char_type;
     struct category
         : dual_use,
-          filter_tag,
+          seekable_filter_tag,
           multichar_tag,
           optimally_buffered_tag
         { };
@@ -57,6 +57,21 @@ public:
         lines_ += std::count(s, s + result, char_traits<Ch>::newline());
         chars_ += result;
         return result;
+    }
+
+    template<typename Device>
+    std::streampos seek(Device &dev, stream_offset off, BOOST_IOS::seekdir way)
+    {
+        chars_ = iostreams::seek(dev, off, way);
+        return chars_;
+    }
+
+    template<typename Device>
+    std::streampos seek(Device &dev, stream_offset off, BOOST_IOS::seekdir way,
+        BOOST_IOS::openmode which)
+    {
+        chars_ = iostreams::seek(dev, off, way, which);
+        return chars_;
     }
 
     template<typename Sink>

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -21,7 +21,7 @@
 
 int
 g3_istream_from_path(g3_istream &stream, const std::string &path,
-    float timeout, size_t buffersize)
+    float timeout, size_t buffersize, bool counter)
 {
 	stream.reset();
 	if (path.size() > 3 && !path.compare(path.size() - 3, 3, ".gz"))
@@ -33,6 +33,9 @@ g3_istream_from_path(g3_istream &stream, const std::string &path,
 		log_fatal("Boost not compiled with bzip2 support.");
 #endif
 	}
+
+	if (counter)
+		stream.push(boost::iostreams::counter64());
 
 	int fd = -1;
 
@@ -165,7 +168,13 @@ g3_istream_seek(g3_istream &stream, off_t offset)
 off_t
 g3_istream_tell(g3_istream &stream)
 {
-	return boost::iostreams::seek(stream, 0, std::ios_base::cur);
+	boost::iostreams::counter64 *counter =
+	    stream.component<boost::iostreams::counter64>(
+	    stream.size() - 2);
+	if (!counter)
+		log_fatal("Could not get stream counter");
+
+	return counter->characters();
 }
 
 void

--- a/core/tests/fileio.py
+++ b/core/tests/fileio.py
@@ -63,7 +63,7 @@ assert n == 10, 'Wrong number of frames read (%d should be %d)' % (n, 10)
 # Indexing
 class CachingReader:
     def __init__(self, filename='test.g3'):
-        self.reader = core.G3Reader(filename='test.g3')
+        self.reader = core.G3Reader(filename='test.g3', counter=True)
         self.w_pos = None
 
     def __call__(self, frame):
@@ -88,7 +88,7 @@ assert cacher.w_pos is not None, 'Missing wiring frame'
 # Using cached index
 class CachedReader:
     def __init__(self, filename='test.g3', start=None):
-        self.reader = core.G3Reader(filename=filename)
+        self.reader = core.G3Reader(filename=filename, counter=True)
         self.pos = start
 
     def __call__(self, frame):


### PR DESCRIPTION
Implement a byte counter as a boost istream filter to avoid buffering in the kernel.  This should speed up read IO for frame indexing.