### PR TITLE
Use sys/time.h on all systems for gettimeofday()

### DIFF
--- a/core/src/G3TimeStamp.cxx
+++ b/core/src/G3TimeStamp.cxx
@@ -2,11 +2,7 @@
 #include <serialization.h>
 
 #include <stdint.h>
-#ifdef __APPLE__
 #include <sys/time.h>
-#else
-#include <time.h>
-#endif
 #include <sstream>
 #include <iomanip>
 


### PR DESCRIPTION
On some linux systems, `gettimeofday()` is only declared in `sys/time.h` (not `time.h`).  This PR just includes `sys/time.h` on all systems.  It seems like [that is the standard header to include](https://pubs.opengroup.org/onlinepubs/009604599/functions/gettimeofday.html).