### PR TITLE
Updates to wheel building

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,10 @@ name: CMake
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
@@ -77,7 +81,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/${{matrix.toolset}}
       shell: bash
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C $BUILD_TYPE --output-on-failure
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_BEFORE_ALL_LINUX: yum install -y bzip2-devel netcdf-devel
-          CIBW_BEFORE_ALL_MACOS: echo "" > /dev/null
+          CIBW_BEFORE_ALL_MACOS: brew install netcdf
           CIBW_BEFORE_BUILD_MACOS: >
             ln -s $(dirname $(readlink -f $(which python3)))/python3-config $(dirname $(which python3))/python3-config &&
             pip install cmake && ./deps/install_flac.sh && ./deps/install_boost.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels for ${{ matrix.build }}
@@ -29,6 +33,9 @@ jobs:
           - os: macos-13
             build: cp312-macosx_x86_64
             target: 13.0
+          - os: macos-13
+            build: cp313-macosx_x86_64
+            target: 13.0
 
           - os: macos-14
             build: cp39-macosx_arm64
@@ -42,6 +49,9 @@ jobs:
           - os: macos-14
             build: cp312-macosx_arm64
             target: 14.0
+          - os: macos-14
+            build: cp313-macosx_arm64
+            target: 14.0
 
           - os: ubuntu-latest
             build: cp38-manylinux_x86_64
@@ -53,6 +63,8 @@ jobs:
             build: cp311-manylinux_x86_64
           - os: ubuntu-latest
             build: cp312-manylinux_x86_64
+          - os: ubuntu-latest
+            build: cp313-manylinux_x86_64
 
     steps:
       - name: Set macOS deployment target
@@ -71,17 +83,33 @@ jobs:
           fetch-tags: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
-          CIBW_BEFORE_ALL_LINUX: yum install -y bzip2-devel flac-devel netcdf-devel
-          CIBW_BEFORE_ALL_MACOS: brew install bzip2 flac netcdf
-          CIBW_BEFORE_BUILD: ./deps/install_boost.sh
+          CIBW_BEFORE_ALL_LINUX: yum install -y bzip2-devel netcdf-devel
+          CIBW_BEFORE_ALL_MACOS: echo "" > /dev/null
+          CIBW_BEFORE_BUILD_MACOS: >
+            ln -s $(dirname $(readlink -f $(which python3)))/python3-config $(dirname $(which python3))/python3-config &&
+            pip install cmake && ./deps/install_flac.sh && ./deps/install_boost.sh
+          CIBW_BEFORE_BUILD_LINUX: >
+            pip install cmake && ./deps/install_flac.sh && ./deps/install_boost.sh
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            LD_LIBRARY_PATH=$PWD/deps/lib auditwheel repair -w {dest_dir} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=$PWD/deps/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_ENVIRONMENT: >
-            CMAKE_BUILD_PARALLEL_LEVEL=4 CMAKE_PREFIX_PATH=$PWD/deps
+          CIBW_ENVIRONMENT_LINUX: >
+            CMAKE_BUILD_PARALLEL_LEVEL=4
+            CMAKE_PREFIX_PATH=$PWD/deps
+            CC=gcc
+            CXX=g++
+            CFLAGS="-O3 -fPIC"
+          CIBW_ENVIRONMENT_MACOS: >
+            CMAKE_BUILD_PARALLEL_LEVEL=4
+            CMAKE_PREFIX_PATH=$PWD/deps
+            CC=clang
+            CXX=clang++
+            CFLAGS="-O3 -fPIC"
           CIBW_TEST_COMMAND: ctest --test-dir {package}/build --output-on-failure
 
       - name: Upload artifacts

--- a/cmake/Spt3gIncludes.cmake
+++ b/cmake/Spt3gIncludes.cmake
@@ -55,13 +55,15 @@ macro(add_spt3g_module lib_name)
 	set(mod_name "_lib${lib_name}")
 	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
 		Python_add_library(${mod_name} MODULE WITH_SOABI ${ARGN})
-		if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+			# Assume Linux-style ld linker
 			target_link_options(${mod_name} PUBLIC "LINKER:--no-as-needed")
 		endif()
 	else()
 		add_library(${mod_name} SHARED ${ARGN})
 		set_target_properties(${mod_name} PROPERTIES PREFIX "" SUFFIX ".so")
-		if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+			# Assume Linux-style ld linker
 			set_target_properties(${mod_name} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
 		endif()
 		target_include_directories(${mod_name} PRIVATE ${Python_INCLUDE_DIRS})
@@ -109,26 +111,26 @@ macro(add_spt3g_test_program test_name)
 	                      "SOURCE_FILES;TEST_LABELS;USE_PROJECTS" # multi-value arguments
 	                      ${ARGN}
 	                      )
-	
+
 	add_test(NAME ${PROJECT}/${test_name}
 	         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 	         COMMAND ${PROJECT}-${test_name}
 	         )
-	
+
 	if(ADD_TEST_PROGRAM_TEST_LABELS)
 		set_tests_properties(${PROJECT}/${test_name} PROPERTIES LABELS ${ADD_TEST_PROGRAM_TEST_LABELS})
 	endif(ADD_TEST_PROGRAM_TEST_LABELS)
-	
+
 	if(NOT EXISTS ${PROJECT_BINARY_DIR}/Spt3gTestMain.cxx)
 		file(WRITE ${PROJECT_BINARY_DIR}/Spt3gTestMain.cxx "#include <G3Test.h>\nG3TEST_MAIN_IMPL\n")
 	endif(NOT EXISTS ${PROJECT_BINARY_DIR}/Spt3gTestMain.cxx)
-	
+
 	add_spt3g_executable(${PROJECT}-${test_name}
 	                     ${PROJECT_BINARY_DIR}/Spt3gTestMain.cxx
 	                     ${ADD_TEST_PROGRAM_SOURCE_FILES}
 	                     )
 	target_include_directories(${PROJECT}-${test_name} PRIVATE ${CMAKE_SOURCE_DIR}/cmake)
-	
+
 	foreach(USED_PROJECT ${ADD_TEST_PROGRAM_USE_PROJECTS})
 		target_link_libraries(${PROJECT}-${test_name} ${USED_PROJECT})
 	endforeach(USED_PROJECT ${ADD_TEST_PROGRAM_USE_PROJECTS})

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -2,3 +2,4 @@
 *
 # ...except these files
 !install_boost.sh
+!install_flac.sh

--- a/deps/install_boost.sh
+++ b/deps/install_boost.sh
@@ -15,13 +15,13 @@ else
     cd ${PREFIX}
 fi
 
-boost_version=1_86_0
+boost_version=1_87_0
 boost_dir=boost_${boost_version}
 boost_pkg=${boost_dir}.tar.bz2
 
 if [ ! -e ${boost_pkg} ]; then
     echo "Fetching boost..."
-    curl -SL "https://archives.boost.io/release/1.86.0/source/${boost_pkg}" -o "${boost_pkg}"
+    curl -SL "https://archives.boost.io/release/1.87.0/source/${boost_pkg}" -o "${boost_pkg}"
 fi
 
 if [ ! -e ${boost_dir} ]; then
@@ -38,10 +38,18 @@ if [ ! -e b2 ]; then
         --with-libraries="iostreams,python,regex"
 fi
 
+extra_include=""
+extra_link=""
+if [ $(uname) = "Darwin" ]; then
+    # We are building with clang++ on MacOS
+    extra_include="cxxflags=-stdlib=libc++"
+    extra_link="linkflags=-stdlib=libc++"
+fi
+
 echo "Building boost..."
 pyincl=$(for d in $(python3-config --includes | sed -e 's/-I//g'); do echo "include=${d}"; done | xargs)
 ./b2 \
     -j4 -d0 \
-    ${pyincl} \
+    ${pyincl} ${extra_include} ${extra_link} \
     variant=release threading=multi link=shared runtime-link=shared \
     install

--- a/deps/install_flac.sh
+++ b/deps/install_flac.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# Location of this script
+pushd $(dirname $0) >/dev/null 2>&1
+scriptdir=$(pwd)
+popd >/dev/null 2>&1
+echo "Wheel script directory = ${scriptdir}"
+
+if [ -n "$1" ]; then
+    PREFIX=$1
+else
+    PREFIX=${scriptdir}
+    cd ${PREFIX}
+fi
+
+flac_version=1.5.0
+flac_dir=flac-${flac_version}
+flac_pkg=${flac_dir}.tar.gz
+
+echo "Fetching libFLAC..."
+
+if [ ! -e ${flac_pkg} ]; then
+    curl -SL "https://github.com/xiph/flac/archive/refs/tags/${flac_version}.tar.gz" -o "${flac_pkg}"
+fi
+
+echo "Building libFLAC..."
+
+rm -rf ${flac_dir}
+tar xzf ${flac_pkg} \
+    && pushd ${flac_dir} >/dev/null 2>&1 \
+    && mkdir -p build \
+    && pushd build >/dev/null 2>&1 \
+    && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DBUILD_DOCS=OFF \
+    -DWITH_OGG=OFF \
+    -DBUILD_CXXLIBS=OFF \
+    -DBUILD_PROGRAMS=OFF \
+    -DBUILD_UTILS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DINSTALL_MANPAGES=OFF \
+    -DENABLE_MULTITHREADING=ON \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    .. \
+    && make -j 4 install \
+    && popd >/dev/null 2>&1 \
+    && popd >/dev/null 2>&1


### PR DESCRIPTION
- Bump vendored version of boost to 1.87, to enable support for numpy-2.

- Bump cibuildwheel version and add a dependabot workflow to keep actions up to date.

- Add a fix for macos wheel builds (see https://github.com/pypa/cibuildwheel/issues/2021)

- Add python-3.13 to the wheel build matrix.

- Change no-as-needed linking option to be based on OS flavor rather than compiler.

- Compile libflac as well as boost when building wheels.  Bump this vendored version to 1.5.0 which includes threaded compression.