### PR TITLE
Use STL seekg/tellg for G3Reader frame indexing

### DIFF
--- a/core/include/core/dataio.h
+++ b/core/include/core/dataio.h
@@ -31,26 +31,6 @@ int g3_istream_from_path(g3_istream &stream, const std::string &path,
     float timeout=-1.0, size_t buffersize=1024*1024);
 
 /**
- * Seek to a byte offset in an open input file stream.
- *
- * @param  stream   A reference to the filtering istream, e.g. as configured by
- *                  g3_istream_from_path.
- * @param  offset   File offset to seek to, in bytes, relative to the beginning
- *                  of the file.
- * @return New read head position, or -1 on error.
- */
-off_t g3_istream_seek(g3_istream &stream, off_t offset);
-
-/**
- * Return the current read head position in an open input file stream.
- *
- * @param  stream   A reference to the filtering istream, e.g. as configured by
- *                  g3_istream_from_path.
- * @return Current read head position, or -1 on error.
- */
-off_t g3_istream_tell(g3_istream &stream);
-
-/**
  * Configure a filtering stream for G3Frame compression to a local file.
  *
  * @param  stream   A reference to the filtering ostream that will be configured

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -100,15 +100,14 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 }
 
 off_t G3Reader::Seek(off_t offset) {
-	try {
-		return g3_istream_seek(stream_, offset);
-	} catch (...) {
+	if (stream_.peek() == EOF && offset != Tell())
 		log_fatal("Cannot seek %s; stream closed at EOF.", cur_file_.c_str());
-	}
+	stream_.seekg(offset, std::ios_base::beg);
+	return offset;
 }
 
 off_t G3Reader::Tell() {
-	return g3_istream_tell(stream_);
+	return stream_.tellg();
 }
 
 PYBINDINGS("core") {

--- a/core/src/dataio.cxx
+++ b/core/src/dataio.cxx
@@ -162,20 +162,6 @@ g3_istream_from_path(g3_istream &stream, const std::string &path,
 	return fd;
 }
 
-off_t
-g3_istream_seek(g3_istream &stream, off_t offset)
-{
-	if (stream.peek() == EOF && offset != g3_istream_tell(stream))
-		log_fatal("Cannot seek stream, closed at EOF.");
-	return boost::iostreams::seek(stream, offset, std::ios_base::beg);
-}
-
-off_t
-g3_istream_tell(g3_istream &stream)
-{
-	return boost::iostreams::seek(stream, 0, std::ios_base::cur);
-}
-
 void
 g3_ostream_to_path(g3_ostream &stream, const std::string &path,
     bool append, bool counter)


### PR DESCRIPTION
This fixes a regression caused by the boost::iostreams variant.

Profiling files with many thousands of frames reproduces the problem and verifies the solution.