### PR TITLE
Hide boost::iostreams implementation behind smart pointers

### DIFF
--- a/core/include/core/G3Reader.h
+++ b/core/include/core/G3Reader.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <dataio.h>
+#include <iostream>
 
 #include <G3Module.h>
 
@@ -25,7 +25,7 @@ private:
 	bool prefix_file_;
 	std::string cur_file_;
 	std::deque<std::string> filename_;
-	g3_istream stream_;
+	std::shared_ptr<std::istream> stream_;
 	int n_frames_to_read_;
 	int n_frames_read_;
 	int n_frames_cur_;

--- a/core/include/core/G3Writer.h
+++ b/core/include/core/G3Writer.h
@@ -2,7 +2,7 @@
 #define _G3_ARCWRITER_H
 
 #include <string>
-#include <dataio.h>
+#include <iostream>
 
 #include <G3Module.h>
 
@@ -13,12 +13,11 @@ public:
 	// Writes to file <filename> all frames with types in <streams>.
 	// If <streams> is empty (default), writes all frames.
 
-	virtual ~G3Writer();
 	void Process(G3FramePtr frame, std::deque<G3FramePtr> &out);
 	void Flush();
 private:
 	std::string filename_;
-	g3_ostream stream_;
+	std::shared_ptr<std::ostream> stream_;
 	std::vector<G3Frame::FrameType> streams_;
 
 	SET_LOGGER("G3Writer");

--- a/core/src/G3Frame.cxx
+++ b/core/src/G3Frame.cxx
@@ -3,7 +3,6 @@
 #include <G3Quat.h>
 #include <serialization.h>
 #include <pybindings.h>
-#include <dataio.h>
 
 #include <stdlib.h>
 #include <cxxabi.h>
@@ -382,12 +381,12 @@ void G3Frame::blob_encode(struct blob_container &blob)
 	item_os.flush();
 }
 
-template void G3Frame::loads(g3_istream &);
+template <> void G3Frame::loads(std::shared_ptr<std::istream> &is) { loads(*is); }
 template void G3Frame::loads(G3BufferInputStream &);
 template void G3Frame::loads(std::istream &);
 template void G3Frame::loads(std::istringstream &);
 
-template void G3Frame::saves(g3_ostream &) const;
+template <> void G3Frame::saves(std::shared_ptr<std::ostream> &os) const { saves(*os); }
 template void G3Frame::saves(G3BufferOutputStream &) const;
 template void G3Frame::saves(std::ostream &) const;
 template void G3Frame::saves(std::ostringstream &) const;

--- a/core/src/G3Reader.cxx
+++ b/core/src/G3Reader.cxx
@@ -34,7 +34,7 @@ void G3Reader::StartFile(std::string path)
 	log_info("Starting file %s\n", path.c_str());
 	cur_file_ = path;
 	n_frames_cur_ = 0;
-	(void) g3_istream_from_path(stream_, path, timeout_, buffersize_);
+	stream_ = g3_istream_from_path(path, timeout_, buffersize_);
 }
 
 void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
@@ -71,7 +71,7 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 	// function reacquire the lock, if it was released.
 	G3PythonContext ctx("G3Reader", false);
 
-	while (stream_.peek() == EOF) {
+	while (stream_->peek() == EOF) {
 		if (n_frames_cur_ == 0)
 			log_error("Empty file %s", cur_file_.c_str());
 		if (filename_.size() > 0) {
@@ -100,14 +100,14 @@ void G3Reader::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 }
 
 off_t G3Reader::Seek(off_t offset) {
-	if (stream_.peek() == EOF && offset != Tell())
+	if (stream_->peek() == EOF && offset != Tell())
 		log_fatal("Cannot seek %s; stream closed at EOF.", cur_file_.c_str());
-	stream_.seekg(offset, std::ios_base::beg);
+	stream_->seekg(offset, std::ios_base::beg);
 	return offset;
 }
 
 off_t G3Reader::Tell() {
-	return stream_.tellg();
+	return stream_->tellg();
 }
 
 PYBINDINGS("core") {

--- a/core/src/G3Writer.cxx
+++ b/core/src/G3Writer.cxx
@@ -8,12 +8,7 @@ G3Writer::G3Writer(std::string filename,
     filename_(filename), streams_(streams)
 {
 	g3_check_output_path(filename);
-	g3_ostream_to_path(stream_, filename, append);
-}
-
-G3Writer::~G3Writer()
-{
-	stream_.reset();
+	stream_ = g3_ostream_to_path(filename, append);
 }
 
 void G3Writer::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
@@ -38,9 +33,10 @@ void G3Writer::Process(G3FramePtr frame, std::deque<G3FramePtr> &out)
 
 void G3Writer::Flush()
 {
-    if (!stream_.strict_sync()){
-        printf("There was a problem flushing the stream...\n");
-    }
+	try {
+		g3_ostream_flush(stream_);
+	} catch (...) {
+	}
 }
 
 PYBINDINGS("core") {


### PR DESCRIPTION
This allows eventually rewriting the file IO ABI while ensuring STL iostream compatibility.