### PR TITLE
Preserve insertion order in G3TimestreamMap

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -133,4 +133,5 @@ add_spt3g_test_program(test
                        SOURCE_FILES
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamTest.cxx
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/G3TimestreamMapTest.cxx
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/OrderedMapTest.cxx
                        USE_PROJECTS core)

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -272,7 +272,8 @@ public:
 		}
 	}
 
-	template <class A> void serialize(A &ar, unsigned v);
+	template <class A> void load(A &ar, unsigned v);
+	template <class A> void save(A &ar, unsigned v) const;
 	std::string Description() const;
 };
 
@@ -280,7 +281,7 @@ G3_POINTERS(G3TimestreamMap);
 
 namespace cereal {
 	template <class A> struct specialize<A, G3Timestream, cereal::specialization::member_load_save> {};
-	template <class A> struct specialize<A, G3TimestreamMap, cereal::specialization::member_serialize> {};
+	template <class A> struct specialize<A, G3TimestreamMap, cereal::specialization::member_load_save> {};
 }
 
 G3_SERIALIZABLE(G3Timestream, 3);

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -184,10 +184,8 @@ class G3TimestreamMap : public G3FrameObject,
     public OrderedMap<std::string, G3TimestreamPtr>{
 public:
 	G3TimestreamMap(){}
-	G3TimestreamMap(const G3TimestreamMap& other) :
-	    OrderedMap<std::string, G3TimestreamPtr>(other) {}
-	G3TimestreamMap(G3TimestreamMap&& other) :
-	    OrderedMap<std::string, G3TimestreamPtr>(std::move(other)) {}
+	G3TimestreamMap(const G3TimestreamMap& other):OrderedMap<std::string, G3TimestreamPtr>(other){}
+	G3TimestreamMap(G3TimestreamMap&& other):OrderedMap<std::string, G3TimestreamPtr>(std::move(other)){}
 
 	G3TimestreamMap& operator=(const G3TimestreamMap&)=default;
 	G3TimestreamMap& operator=(G3TimestreamMap&&)=default;

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -267,7 +267,7 @@ public:
 			ts->data_ = data.get() + offset;
 			ts->data_type_ = data_type;
 			ts->len_ = n_samples;
-			insert({key, std::move(ts)});
+			emplace(key, std::move(ts));
 			offset += n_samples;
 		}
 	}

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -272,8 +272,7 @@ public:
 		}
 	}
 
-	template <class A> void load(A &ar, unsigned v);
-	template <class A> void save(A &ar, unsigned v) const;
+	template <class A> void serialize(A &ar, unsigned v);
 	std::string Description() const;
 };
 
@@ -281,7 +280,7 @@ G3_POINTERS(G3TimestreamMap);
 
 namespace cereal {
 	template <class A> struct specialize<A, G3Timestream, cereal::specialization::member_load_save> {};
-	template <class A> struct specialize<A, G3TimestreamMap, cereal::specialization::member_load_save> {};
+	template <class A> struct specialize<A, G3TimestreamMap, cereal::specialization::member_serialize> {};
 }
 
 G3_SERIALIZABLE(G3Timestream, 3);

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -282,7 +282,7 @@ namespace cereal {
 }
 
 G3_SERIALIZABLE(G3Timestream, 3);
-G3_SERIALIZABLE(G3TimestreamMap, 4);
+G3_SERIALIZABLE(G3TimestreamMap, 3);
 
 #endif
 

--- a/core/include/core/G3Timestream.h
+++ b/core/include/core/G3Timestream.h
@@ -5,7 +5,7 @@
 #include <G3TimeStamp.h>
 #include <G3Vector.h>
 #include <vector>
-#include <map>
+#include <containers.h>
 
 class G3Timestream : public G3FrameObject {
 public:
@@ -181,11 +181,13 @@ struct G3Timestream::TimeStreamTypeResolver<int64_t>{
 };
 
 class G3TimestreamMap : public G3FrameObject,
-    public std::map<std::string, G3TimestreamPtr> {
+    public OrderedMap<std::string, G3TimestreamPtr>{
 public:
 	G3TimestreamMap(){}
-	G3TimestreamMap(const G3TimestreamMap& other):std::map<std::string, G3TimestreamPtr>(other){}
-	G3TimestreamMap(G3TimestreamMap&& other):std::map<std::string, G3TimestreamPtr>(std::move(other)){}
+	G3TimestreamMap(const G3TimestreamMap& other) :
+	    OrderedMap<std::string, G3TimestreamPtr>(other) {}
+	G3TimestreamMap(G3TimestreamMap&& other) :
+	    OrderedMap<std::string, G3TimestreamPtr>(std::move(other)) {}
 
 	G3TimestreamMap& operator=(const G3TimestreamMap&)=default;
 	G3TimestreamMap& operator=(G3TimestreamMap&&)=default;
@@ -253,8 +255,6 @@ public:
 	void FromBuffer(const std::vector<std::string>& keys, std::size_t n_samples,
 	    std::shared_ptr<SampleType[]> data, G3Time start, G3Time stop,
 	    G3Timestream::TimestreamUnits units=G3Timestream::None, int compression_level=0) {
-		if(!std::is_sorted(keys.begin(), keys.end()))
-			throw std::runtime_error("G3TimestreamMap::MakeCompact: keys must be sorted");
 		const auto data_type=G3Timestream::TimeStreamTypeResolver<SampleType>::type_tag;
 		std::size_t offset = 0;
 		for (const auto& key : keys) {
@@ -267,7 +267,7 @@ public:
 			ts->data_ = data.get() + offset;
 			ts->data_type_ = data_type;
 			ts->len_ = n_samples;
-			emplace(key, std::move(ts));
+			insert({key, std::move(ts)});
 			offset += n_samples;
 		}
 	}
@@ -284,7 +284,7 @@ namespace cereal {
 }
 
 G3_SERIALIZABLE(G3Timestream, 3);
-G3_SERIALIZABLE(G3TimestreamMap, 3);
+G3_SERIALIZABLE(G3TimestreamMap, 4);
 
 #endif
 

--- a/core/include/core/containers.h
+++ b/core/include/core/containers.h
@@ -1,0 +1,172 @@
+#ifndef _G3_CONTAINERS_H
+#define _G3_CONTAINERS_H
+
+#include <vector>
+#include <unordered_map>
+#include <iterator>
+
+template <typename K, typename T>
+class OrderedMap {
+public:
+	using map_type = std::unordered_map<K, T>;
+	using key_map_type = std::vector<K>;
+	using key_type = K;
+	using mapped_type = T;
+	using value_type = typename map_type::value_type;
+	using difference_type = typename map_type::difference_type;
+	using size_type = typename map_type::size_type;
+
+	OrderedMap() {};
+	OrderedMap(const OrderedMap& other) :
+	    map_(other.map_), keys_(other.keys_) {}
+	OrderedMap(OrderedMap&& other) :
+	    map_(std::move(other.map_)), keys_(std::move(other.keys_)) {}
+	virtual ~OrderedMap() {};
+
+	OrderedMap& operator=(const OrderedMap&) = default;
+	OrderedMap& operator=(OrderedMap&&) = default;
+
+	mapped_type& operator[](const key_type& key) {
+		auto it = std::find(keys_.begin(), keys_.end(), key);
+		if (it == keys_.end())
+			keys_.push_back(key);
+		return map_[key];
+	}
+	const mapped_type& operator[](const key_type& key) const { return map_.at(key); }
+	mapped_type& at(const key_type& key) { return map_.at(key); }
+	const mapped_type& at(const key_type& key) const { return map_.at(key); }
+	bool contains(const key_type& key) const { return map_.count(key) > 0; }
+
+	size_type size() const { return map_.size(); }
+	size_type max_size() const { return map_.max_size(); }
+	bool empty() const { return map_.empty(); }
+
+	void clear() {
+		map_.clear();
+		keys_.clear();
+	}
+
+	size_type erase(const key_type& key) {
+		auto it = std::find(keys_.begin(), keys_.end(), key);
+		if (it == keys_.end())
+			return 0;
+
+		keys_.erase(it);
+		return map_.erase(key);
+	}
+
+	class iterator {
+	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = typename map_type::value_type;
+		using difference_type = typename map_type::difference_type;
+		using pointer = value_type*;
+		using reference = value_type&;
+
+		typename key_map_type::iterator cur;
+		map_type& map;
+
+		iterator(typename key_map_type::iterator it, map_type& map) :
+		    cur(it), map(map) {}
+
+		iterator& operator++() {
+			++cur;
+			return *this;
+		}
+
+		iterator operator++(int) {
+			iterator tmp = *this;
+			++(*this);
+			return tmp;
+		}
+
+		bool operator==(const iterator& other) const { return cur == other.cur; }
+		bool operator!=(const iterator& other) const { return cur != other.cur; }
+
+		pointer operator->() const { return &(*(map.find(*cur))); }
+		reference operator*() const { return *(map.find(*cur)); }
+	};
+
+	class const_iterator {
+	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = typename map_type::value_type;
+		using difference_type = typename map_type::difference_type;
+		using pointer = const value_type*;
+		using reference = const value_type&;
+
+		typename key_map_type::const_iterator cur;
+		const map_type& map;
+
+		const_iterator(typename key_map_type::const_iterator it,
+		    const map_type& map) : cur(it), map(map) {}
+
+		const_iterator(const iterator& other) : cur(other.cur), map(other.map) {}
+
+		const_iterator& operator++() {
+			++cur;
+			return *this;
+		}
+
+		const_iterator operator++(int) {
+			const_iterator tmp = *this;
+			++(*this);
+			return tmp;
+		}
+
+		bool operator==(const const_iterator& other) const { return cur == other.cur; }
+		bool operator!=(const const_iterator& other) const { return cur != other.cur; }
+
+		pointer operator->() const { return &(*(map.find(*cur))); }
+		reference operator*() const { return *(map.find(*cur)); }
+	};
+
+	iterator begin() { return iterator(keys_.begin(), map_); }
+	iterator end() { return iterator(keys_.end(), map_); }
+	const_iterator begin() const { return const_iterator(keys_.begin(), map_); }
+	const_iterator end() const { return const_iterator(keys_.end(), map_); }
+	const_iterator cbegin() const { return const_iterator(keys_.cbegin(), map_); }
+	const_iterator cend() const { return const_iterator(keys_.cend(), map_); }
+
+	iterator find(const key_type& key) {
+		return iterator(std::find(keys_.begin(), keys_.end(), key), map_);
+	}
+
+	const_iterator find(const key_type& key) const {
+		return const_iterator(std::find(keys_.cbegin(), keys_.cend(), key), map_);
+	}
+
+	std::pair<iterator, bool> insert(const value_type& pair) {
+		const key_type& key = pair.first;
+
+		bool check = false;
+		auto it = std::find(keys_.begin(), keys_.end(), key);
+		if (it == keys_.end()) {
+			keys_.push_back(key);
+			it = std::prev(keys_.end());
+			check = true;
+		}
+		map_.insert(pair);
+		return {iterator(it, map_), check};
+	}
+
+	std::pair<iterator, bool> insert(value_type&& pair) {
+		const key_type& key = pair.first;
+
+		bool check = false;
+		auto it = std::find(keys_.begin(), keys_.end(), key);
+		if (it == keys_.end()) {
+			keys_.push_back(key);
+			it = std::prev(keys_.end());
+			check = true;
+		}
+		map_.insert(pair);
+		return {iterator(it, map_), check};
+	}
+
+protected:
+	map_type map_;
+	key_map_type keys_;
+};
+
+#endif

--- a/core/include/core/containers.h
+++ b/core/include/core/containers.h
@@ -410,8 +410,8 @@ template<typename Key, typename T, typename Hash, typename Pred,
          typename DataAlloc, typename IndexAlloc>
 bool operator==(const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& a,
                 const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& b){
-    if(a.size()!=b.size())
-    	return false;
+	if(a.size()!=b.size())
+		return false;
 	return std::equal(a.cbegin(), a.cend(), b.cbegin());
 }
 
@@ -420,7 +420,7 @@ template<typename Key, typename T, typename Hash, typename Pred,
 bool operator!=(const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& a,
                 const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& b){
 	if(a.size()==b.size())
-    	return false;
+		return false;
 	return !std::equal(a.cbegin(), a.cend(), b.cbegin());
 }
 

--- a/core/include/core/containers.h
+++ b/core/include/core/containers.h
@@ -1,172 +1,445 @@
-#ifndef _G3_CONTAINERS_H
-#define _G3_CONTAINERS_H
+#ifndef G3_CONTAINERS_H
+#define G3_CONTAINERS_H
 
-#include <vector>
+#include <algorithm>
+#include <list>
 #include <unordered_map>
-#include <iterator>
 
-template <typename K, typename T>
-class OrderedMap {
+///This is an ordered associative container which supports unique keys.
+///It supports bidirectional iterators.
+///The ordering of entries in this container is unrelated to their keys;
+///instead it is the order in which they were inserted.
+template <typename K, typename T,
+          typename Hash=std::hash<K>,
+          typename Pred=std::equal_to<K>,
+          typename DataAlloc = std::allocator<std::pair<const K, T>>,
+          typename IndexAlloc = std::allocator<std::pair<const K,
+                                    typename std::list<std::pair<const K, T>>::iterator>>>
+class OrderedMap{
 public:
-	using map_type = std::unordered_map<K, T>;
-	using key_map_type = std::vector<K>;
 	using key_type = K;
 	using mapped_type = T;
-	using value_type = typename map_type::value_type;
-	using difference_type = typename map_type::difference_type;
-	using size_type = typename map_type::size_type;
-
-	OrderedMap() {};
-	OrderedMap(const OrderedMap& other) :
-	    map_(other.map_), keys_(other.keys_) {}
+	using value_type = std::pair<const key_type, mapped_type>;
+	using hasher = Hash;
+	using key_equal = Pred;
+	using allocator_type = DataAlloc;
+	using index_allocator_type = IndexAlloc;
+	using reference = value_type&;
+	using const_reference = const value_type&;
+	using pointer = typename std::allocator_traits<allocator_type>::pointer;
+	using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+protected:
+	using data_store_type = std::list<value_type, DataAlloc>;
+public:
+	using iterator = typename data_store_type::iterator;
+	using const_iterator = typename data_store_type::const_iterator;
+	using reverse_iterator = typename data_store_type::reverse_iterator;
+	using const_reverse_iterator = typename data_store_type::const_reverse_iterator;
+	//Not implemented: local iterators
+	using size_type = typename data_store_type::size_type;
+	using difference_type = typename data_store_type::difference_type;
+protected:
+	using index_type = std::unordered_map<K, iterator, Hash, Pred, IndexAlloc>;
+public:
+	
+	OrderedMap(){};
+	
+	explicit OrderedMap(size_type n, const hasher& hf = hasher(),
+	                    const key_equal& eql = key_equal(),
+	                    const allocator_type& da = allocator_type(),
+	                    const index_allocator_type& ia = index_allocator_type()):
+	data_(n,hf,eql,da),index_(ia){}
+	
+	template<class InputIterator>
+	OrderedMap(InputIterator f, InputIterator l, size_type n = 0,
+	           const hasher& hf = hasher(),
+	           const key_equal& eql = key_equal(),
+	           const allocator_type& da = allocator_type(),
+	           const index_allocator_type& ia = index_allocator_type()):
+	data_(n,hf,eql,da),index_(ia){
+		while(f!=l)
+			insert(*f++);
+	}
+	
+	template<class InputIterator>
+	OrderedMap(std::initializer_list<value_type> il, size_type n = 0,
+	           const hasher& hf = hasher(),
+	           const key_equal& eql = key_equal(),
+	           const allocator_type& da = allocator_type(),
+	           const index_allocator_type& ia = index_allocator_type()):
+	data_(n,hf,eql,da),index_(ia){
+		for(value_type&& val : il)
+			insert(std::move(val));
+	}
+	
+	explicit OrderedMap(const allocator_type& da,
+	                    const index_allocator_type& ia = index_allocator_type()):
+	data_(da),index_(ia){}
+	
+	OrderedMap(const OrderedMap& other):
+	data_(other.data_),index_(other.index_){}
+	
 	OrderedMap(OrderedMap&& other) :
-	    map_(std::move(other.map_)), keys_(std::move(other.keys_)) {}
-	virtual ~OrderedMap() {};
+	    data_(std::move(other.data_)),index_(std::move(other.index_)){}
+	virtual ~OrderedMap(){};
+	
+	OrderedMap(const OrderedMap& other, const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	data_(other.data_, da),index_(other.index_, ia){}
+	
+	OrderedMap(size_type n, const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(n, hasher(), key_equal(), da, ia){}
+	
+	OrderedMap(size_type n, const hasher& hf, const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(n, hf, key_equal(), da, ia){}
+	
+	template<class InputIterator>
+	OrderedMap(InputIterator f, InputIterator l, size_type n,
+	           const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(f, l, n, hasher(), key_equal(), da, ia){}
+	
+	template<class InputIterator>
+	OrderedMap(InputIterator f, InputIterator l, size_type n,
+	           const hasher& hf,
+	           const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(f, l, n, hf, key_equal(), da, ia){}
+	
+	OrderedMap(std::initializer_list<value_type> il, size_type n, const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(il, n, hasher(), key_equal(), da, ia){}
+
+	OrderedMap(std::initializer_list<value_type> il, size_type n, const hasher& hf,
+	           const allocator_type& da,
+	           const index_allocator_type& ia = index_allocator_type()):
+	OrderedMap(il, n, hf, key_equal(), da, ia){}
 
 	OrderedMap& operator=(const OrderedMap&) = default;
 	OrderedMap& operator=(OrderedMap&&) = default;
-
-	mapped_type& operator[](const key_type& key) {
-		auto it = std::find(keys_.begin(), keys_.end(), key);
-		if (it == keys_.end())
-			keys_.push_back(key);
-		return map_[key];
+	OrderedMap& operator=(std::initializer_list<value_type> il){
+		clear();
+		for(value_type&& val : il)
+			insert(std::move(val));
+		return *this;
 	}
-	const mapped_type& operator[](const key_type& key) const { return map_.at(key); }
-	mapped_type& at(const key_type& key) { return map_.at(key); }
-	const mapped_type& at(const key_type& key) const { return map_.at(key); }
-	bool contains(const key_type& key) const { return map_.count(key) > 0; }
-
-	size_type size() const { return map_.size(); }
-	size_type max_size() const { return map_.max_size(); }
-	bool empty() const { return map_.empty(); }
-
-	void clear() {
-		map_.clear();
-		keys_.clear();
+	
+	allocator_type get_allocator() const noexcept{ return data_.get_allocator(); }
+	index_allocator_type get_index_allocator() const noexcept{ return index_.get_allocator(); }
+	
+	iterator begin() noexcept{ return data_.begin(); }
+	iterator end() noexcept{ return data_.end(); }
+	const_iterator begin() const noexcept{ return data_.begin(); }
+	const_iterator end() const noexcept{ return data_.end(); }
+	const_iterator cbegin() const noexcept{ return data_.cbegin(); }
+	const_iterator cend() const noexcept{ return data_.cend(); }
+	reverse_iterator rbegin() noexcept{ return data_.rbegin(); }
+	reverse_iterator rend() noexcept{ return data_.rend(); }
+	const_reverse_iterator rbegin() const noexcept{ return data_.rbegin(); }
+	const_reverse_iterator rend() const noexcept{ return data_.rend(); }
+	const_reverse_iterator crbegin() const noexcept{ return data_.crbegin(); }
+	const_reverse_iterator crend() const noexcept{ return data_.crend(); }
+	
+	bool empty() const noexcept{ return index_.empty(); }
+	size_type size() const noexcept{ return index_.size(); }
+	size_type max_size() const noexcept{ return data_.max_size(); }
+	
+	template <class... Args>
+	std::pair<iterator,bool> emplace(Args&&... args){
+		value_type val(std::forward<Args>(args)...);
+		auto iit=index_.find(val.first);
+		if(iit!=index_.end())
+			return std::make_pair(iit->second, false);
+		data_.emplace_back(std::move(val));
+		auto it=data_.end();
+		it--;
+		index_.insert(make_pair(val.first, it));
+		return std::make_pair(it, true);
 	}
-
-	size_type erase(const key_type& key) {
-		auto it = std::find(keys_.begin(), keys_.end(), key);
-		if (it == keys_.end())
+	
+	template <class... Args>
+	iterator emplace_hint(const_iterator, Args&&... args){
+		return emplace(std::forward<Args>(args)...).first;
+	}
+	
+	std::pair<iterator,bool> insert(const value_type& val){
+		auto iit=index_.find(val.first);
+		if(iit!=index_.end())
+			return std::make_pair(iit->second, false);
+		data_.push_back(val);
+		auto it=data_.end();
+		it--;
+		index_.insert(make_pair(val.first, it));
+		return std::make_pair(it, true);
+	}
+	
+	std::pair<iterator,bool> insert(value_type&& val){
+		auto iit=index_.find(val.first);
+		if(iit!=index_.end())
+			return std::make_pair(iit->second, false);
+		data_.emplace_back(std::move(val));
+		auto it=data_.end();
+		it--;
+		index_.insert(make_pair(val.first, it));
+		return std::make_pair(it, true);
+	}
+	
+	template<typename P>
+	std::pair<iterator, bool> insert(P&& obj){
+		return emplace(std::forward<P>(obj));
+	}
+	
+	iterator insert(const_iterator hint, const value_type& obj){
+		return emplace_hint(hint, obj);
+	}
+	
+	iterator insert(const_iterator hint, value_type&& obj){
+		return emplace_hint(hint, std::move(obj));
+	}
+	
+	template<typename P>
+	iterator insert(const_iterator hint, P&& obj){
+		return emplace_hint(hint, std::forward<P>(obj));
+	}
+	
+	template<class InputIterator>
+	void insert(InputIterator first, InputIterator last){
+		while(first!=last)
+			insert(*first++);
+	}
+	
+	void insert(std::initializer_list<value_type> il){
+		for(auto&& v : il)
+			insert(std::move(v));
+	}
+	
+	//Not implemented: (c++17) extract
+	//Not implemented: (c++17) insert(node_type)
+	//Not implemented: (c++17) try_emplace
+	//Not implemented: (c++17) insert_or_assign
+	
+	iterator erase(iterator position){
+		const key_type& key=position->first;
+		iterator result=position;
+		result++;
+		auto iit=index_.find(key);
+		data_.erase(position);
+		index_.erase(iit);
+		return result;
+	}
+	
+	iterator erase(const_iterator position){
+		const key_type& key=position->first;
+		iterator result=position;
+		result++;
+		auto iit=index_.find(key);
+		data_.erase(position);
+		index_.erase(iit);
+		return result;
+	}
+	
+	size_type erase(const key_type& key){
+		auto iit=index_.find(key);
+		if(iit==index_.end())
 			return 0;
-
-		keys_.erase(it);
-		return map_.erase(key);
+		data_.erase(iit->second);
+		index_.erase(iit);
+		return 1;
 	}
-
-	class iterator {
-	public:
-		using iterator_category = std::forward_iterator_tag;
-		using value_type = typename map_type::value_type;
-		using difference_type = typename map_type::difference_type;
-		using pointer = value_type*;
-		using reference = value_type&;
-
-		typename key_map_type::iterator cur;
-		map_type& map;
-
-		iterator(typename key_map_type::iterator it, map_type& map) :
-		    cur(it), map(map) {}
-
-		iterator& operator++() {
-			++cur;
-			return *this;
+	
+	iterator erase(const_iterator first, const_iterator last){
+		//figure out each affected index entry and remove them all
+		for(auto it=first; it!=last; it++){
+			const key_type& key=it->first;
+			auto iit=index_.find(key);
+			index_.erase(iit);
 		}
-
-		iterator operator++(int) {
-			iterator tmp = *this;
-			++(*this);
-			return tmp;
-		}
-
-		bool operator==(const iterator& other) const { return cur == other.cur; }
-		bool operator!=(const iterator& other) const { return cur != other.cur; }
-
-		pointer operator->() const { return &(*(map.find(*cur))); }
-		reference operator*() const { return *(map.find(*cur)); }
-	};
-
-	class const_iterator {
-	public:
-		using iterator_category = std::forward_iterator_tag;
-		using value_type = typename map_type::value_type;
-		using difference_type = typename map_type::difference_type;
-		using pointer = const value_type*;
-		using reference = const value_type&;
-
-		typename key_map_type::const_iterator cur;
-		const map_type& map;
-
-		const_iterator(typename key_map_type::const_iterator it,
-		    const map_type& map) : cur(it), map(map) {}
-
-		const_iterator(const iterator& other) : cur(other.cur), map(other.map) {}
-
-		const_iterator& operator++() {
-			++cur;
-			return *this;
-		}
-
-		const_iterator operator++(int) {
-			const_iterator tmp = *this;
-			++(*this);
-			return tmp;
-		}
-
-		bool operator==(const const_iterator& other) const { return cur == other.cur; }
-		bool operator!=(const const_iterator& other) const { return cur != other.cur; }
-
-		pointer operator->() const { return &(*(map.find(*cur))); }
-		reference operator*() const { return *(map.find(*cur)); }
-	};
-
-	iterator begin() { return iterator(keys_.begin(), map_); }
-	iterator end() { return iterator(keys_.end(), map_); }
-	const_iterator begin() const { return const_iterator(keys_.begin(), map_); }
-	const_iterator end() const { return const_iterator(keys_.end(), map_); }
-	const_iterator cbegin() const { return const_iterator(keys_.cbegin(), map_); }
-	const_iterator cend() const { return const_iterator(keys_.cend(), map_); }
-
-	iterator find(const key_type& key) {
-		return iterator(std::find(keys_.begin(), keys_.end(), key), map_);
+		//erase main entries in bulk
+		return data_.erase(first, last);
 	}
-
-	const_iterator find(const key_type& key) const {
-		return const_iterator(std::find(keys_.cbegin(), keys_.cend(), key), map_);
+	
+	void swap(const OrderedMap& other){
+		data_.swap(other.data_);
+		index_.swap(other.index_);
 	}
-
-	std::pair<iterator, bool> insert(const value_type& pair) {
-		const key_type& key = pair.first;
-
-		bool check = false;
-		auto it = std::find(keys_.begin(), keys_.end(), key);
-		if (it == keys_.end()) {
-			keys_.push_back(key);
-			it = std::prev(keys_.end());
-			check = true;
+	
+	//Not implemented: (c++17) merge
+	
+	hasher hash_function() const{ return index_.hash_function(); }
+	key_equal key_eq() const{ return index_.key_eq(); }
+	
+	iterator find(const key_type& k){
+		auto it=index_.find(k);
+		if(it==index_.end())
+			return end();
+		return it->second;
+	}
+	
+	const_iterator find(const key_type& k) const{
+		auto it=index_.find(k);
+		if(it==index_.end())
+			return end();
+		return it->second;
+	}
+	
+	template<class K2>
+	iterator find(const K2& k){
+		auto it=index_.find(k);
+		if(it==index_.end())
+			return end();
+		return it->second;
+	}
+	
+	template<class K2>
+	const_iterator find(const K2& k) const{
+		auto it=index_.find(k);
+		if(it==index_.end())
+			return end();
+		return it->second;
+	}
+	
+	size_type count(const key_type& key) const{ return index_.count(key); }
+	
+	template<class K2>
+	size_type count(const K2& key) const{ return index_.count(key); }
+	
+	bool contains(const key_type& key) const{ return index_.count(key); }
+	
+	template<class K2>
+	bool contains(const K2& key) const{ return index_.count(key); }
+	
+	std::pair<iterator, iterator> equal_range(const key_type& key){
+		iterator first=find(key);
+		iterator last;
+		if(first==end())
+			last=end();
+		else{
+			last=first;
+			last++;
 		}
-		map_.insert(pair);
-		return {iterator(it, map_), check};
+		return std::make_pair(first, last);
 	}
-
-	std::pair<iterator, bool> insert(value_type&& pair) {
-		const key_type& key = pair.first;
-
-		bool check = false;
-		auto it = std::find(keys_.begin(), keys_.end(), key);
-		if (it == keys_.end()) {
-			keys_.push_back(key);
-			it = std::prev(keys_.end());
-			check = true;
+	
+	std::pair<const_iterator, const_iterator> equal_range(const key_type& key) const{
+		const_iterator first=find(key);
+		const_iterator last;
+		if(first==end())
+			last=end();
+		else{
+			last=first;
+			last++;
 		}
-		map_.insert(pair);
-		return {iterator(it, map_), check};
+		return std::make_pair(first, last);
 	}
-
+	
+	template<class K2>
+	std::pair<iterator, iterator> equal_range(const K2& key){
+		iterator first=find(key);
+		iterator last;
+		if(first==end())
+			last=end();
+		else{
+			last=first;
+			last++;
+		}
+		return std::make_pair(first, last);
+	}
+	
+	template<class K2>
+	std::pair<const_iterator, const_iterator> equal_range(const K2& key) const{
+		const_iterator first=find(key);
+		const_iterator last;
+		if(first==end())
+			last=end();
+		else{
+			last=first;
+			last++;
+		}
+		return std::make_pair(first, last);
+	}
+	
+	mapped_type& operator[](const key_type& key){
+		auto it=index_.find(key);
+		if(it==index_.end()){
+			data_.push_back(std::make_pair(key,mapped_type{}));
+			auto dit=data_.end();
+			dit--;
+			index_[key]=dit;
+			return dit->second;
+		}
+		return it->second->second;
+	}
+	
+	mapped_type& operator[](key_type&& key){
+		auto it=index_.find(key);
+		if(it==index_.end()){
+			data_.push_back(std::make_pair(key,mapped_type{}));
+			auto dit=data_.end();
+			dit--;
+			index_[key]=dit;
+			return dit->second;
+		}
+		return it->second->second;
+	}
+	
+	mapped_type& at(const key_type& k){
+		auto it=index_.at(k);
+		return it->second;
+	}
+	
+	const mapped_type& at(const key_type& k) const{
+		auto it=index_.at(k);
+		return it->second;
+	}
+	
+	size_type bucket_count() const noexcept{ return index_.bucket_count(); }
+	size_type max_bucket_count() const noexcept{ return index_.max_bucket_count(); }
+	size_type bucket_size(size_type n) const{ return index_.bucket_size(n); }
+	size_type bucket(const key_type& k) const{ return index_.bucket(k); }
+	
+	float load_factor() const noexcept{ return index_.load_factor(); }
+	float max_load_factor() const noexcept{ return index_.max_load_factor(); }
+	void max_load_factor(float z){ index_.max_load_factor(z); }
+	void rehash(size_type n){ index_.rehash(n); }
+	void reserve(size_type n){ index_.reserve(n); /*no sensible way to reserve in data_*/}
+	
+	void clear(){
+		data_.clear();
+		index_.clear();
+	}
+	
 protected:
-	map_type map_;
-	key_map_type keys_;
+	data_store_type data_;
+	index_type index_;
 };
+	
+//Not implemented: deduction guides
 
-#endif
+template<typename Key, typename T, typename Hash, typename Pred,
+         typename DataAlloc, typename IndexAlloc>
+bool operator==(const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& a,
+                const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& b){
+    if(a.size()!=b.size())
+    	return false;
+	return std::equal(a.cbegin(), a.cend(), b.cbegin());
+}
+
+template<typename Key, typename T, typename Hash, typename Pred,
+         typename DataAlloc, typename IndexAlloc>
+bool operator!=(const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& a,
+                const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& b){
+	if(a.size()==b.size())
+    	return false;
+	return !std::equal(a.cbegin(), a.cend(), b.cbegin());
+}
+
+template<typename Key, typename T, typename Hash, typename Pred,
+         typename DataAlloc, typename IndexAlloc>
+void swap(const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& x,
+          const OrderedMap<Key, T, Hash, Pred, DataAlloc, IndexAlloc>& y){
+	x.swap(y);
+}
+
+#endif //G3_CONTAINERS_H

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -650,11 +650,6 @@ template <class A> void G3TimestreamMap::serialize(A &ar, unsigned v)
 			this->insert(std::pair<std::string, G3TimestreamPtr>(
 			    i->first, G3TimestreamPtr(new G3Timestream(
 			    i->second))));
-	} else if (v < 4) {
-		std::map<std::string, G3TimestreamPtr> oldmap;
-		ar & cereal::make_nvp("map", oldmap);
-		for (auto &it: oldmap)
-			this->insert(it);
 	} else {
 		ar & cereal::make_nvp("map",
 		    cereal::base_class<OrderedMap<std::string,

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -638,29 +638,7 @@ std::string G3Timestream::Description() const
 	return desc.str();
 }
 
-template <class A> void G3TimestreamMap::save(A &ar, unsigned v) const
-{
-	ar & cereal::make_nvp("G3FrameObject",
-	    cereal::base_class<G3FrameObject>(this));
-	if (v < 3) {
-		std::map<std::string, G3Timestream> oldmap;
-		ar & cereal::make_nvp("map", oldmap);
-	} else if (v < 4) {
-		std::map<std::string, G3TimestreamPtr> oldmap;
-		ar & cereal::make_nvp("map", oldmap);
-	} else {
-		ar & cereal::make_nvp("map", cereal::base_class<OrderedMap<std::string, G3TimestreamPtr>>(this));
-	}
-	if (v < 2) {
-		// Load old timestreams with start/stop in the map instead of
-		// the individual timestreams.
-		G3Time start, stop;
-		ar & cereal::make_nvp("start", start);
-		ar & cereal::make_nvp("stop", stop);
-	}
-}
-
-template <class A> void G3TimestreamMap::load(A &ar, unsigned v)
+template <class A> void G3TimestreamMap::serialize(A &ar, unsigned v)
 {
 	G3_CHECK_VERSION(v);
 
@@ -679,7 +657,9 @@ template <class A> void G3TimestreamMap::load(A &ar, unsigned v)
 		for (auto &it: oldmap)
 			this->insert(it);
 	} else {
-		ar & cereal::make_nvp("map", cereal::base_class<OrderedMap<std::string, G3TimestreamPtr>>(this));
+		ar & cereal::make_nvp("map",
+		    cereal::base_class<OrderedMap<std::string,
+		    G3TimestreamPtr> >(this));
 	}
 	if (v < 2) {
 		// Load old timestreams with start/stop in the map instead of
@@ -902,7 +882,7 @@ void G3TimestreamMap::Compactify()
 }
 
 G3_SPLIT_SERIALIZABLE_CODE(G3Timestream);
-G3_SPLIT_SERIALIZABLE_CODE(G3TimestreamMap);
+G3_SERIALIZABLE_CODE(G3TimestreamMap);
 
 class G3Timestream::G3TimestreamPythonHelpers
 {

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -650,10 +650,14 @@ template <class A> void G3TimestreamMap::serialize(A &ar, unsigned v)
 			this->insert(std::pair<std::string, G3TimestreamPtr>(
 			    i->first, G3TimestreamPtr(new G3Timestream(
 			    i->second))));
+	} else if (v < 4) {
+		std::map<std::string, G3TimestreamPtr> oldmap;
+		ar & cereal::make_nvp("map", oldmap);
+		for (auto &it: oldmap)
+			this->insert(it);
 	} else {
-		ar & cereal::make_nvp("map",
-		    cereal::base_class<std::map<std::string,
-		    G3TimestreamPtr> >(this));
+		ar & cereal::make_nvp("map", map_);
+		ar & cereal::make_nvp("keys", keys_);
 	}
 	if (v < 2) {
 		// Load old timestreams with start/stop in the map instead of

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -5,7 +5,6 @@
 #include <std_map_indexing_suite.hpp>
 #include <boost/python/slice.hpp>
 
-#include <cereal/types/list.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/vector.hpp>
 

--- a/core/tests/G3TimestreamMapTest.cxx
+++ b/core/tests/G3TimestreamMapTest.cxx
@@ -24,12 +24,15 @@ static_assert(std::is_move_assignable<G3TimestreamMap>::value,
 
 template<typename SampleType>
 void testMakeCompact(){
-	std::vector<std::string> keys={"a","b","c","d"};
+	std::vector<std::string> keys={"d","a","b","c"};
 	G3Time t1(0), t2(3);
 	const std::size_t nSamples=4;
 	G3TimestreamMap tsm=G3TimestreamMap::MakeCompact<SampleType>(keys, nSamples, t1, t2);
 	
 	ENSURE_EQUAL(tsm.size(),keys.size(), "MakeCompact should produce the correct number of timestreams");
+	size_t idx = 0;
+	for (const auto & item : tsm)
+		ENSURE_EQUAL(item.first, keys[idx++], "MakeCompact should preserve the key ordering");
 	ENSURE_EQUAL(tsm.GetStartTime(),t1, "MakeCompact should produce a map with the given start time");
 	ENSURE_EQUAL(tsm.GetStopTime(),t2, "MakeCompact should produce a map with the given stop time");
 	ENSURE_EQUAL(tsm.NSamples(),nSamples, "MakeCompact should produce a map with the given number of samples");

--- a/core/tests/OrderedMapTest.cxx
+++ b/core/tests/OrderedMapTest.cxx
@@ -342,13 +342,53 @@ TEST(InitializerListConstruction){
 	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
 }
 
-TEST(InitializerListAssignement){
+TEST(InitializerListAssignment){
 	std::initializer_list<TestValueType> il{{"foo",std::make_shared<std::string>("bar")},
 	                                        {"baz",std::make_shared<std::string>("quux")},
 	                                        {"xen",std::make_shared<std::string>("hom")}};
 	TestMap map({{"drel",std::make_shared<std::string>("plugh")}});
 	map = il;
 	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(CopyConstruction){
+	TestMap m1({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	TestMap m2(m1);
+	ENSURE(m1==m2);
+	m1.clear(); //m2 must in no way depend on m1 continuing to exist/have the same state
+	check_contents(m2, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(MoveConstruction){
+	TestMap m1({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	TestMap m2(std::move(m1));
+	m1.clear(); //m2 must in no way depend on m1 continuing to exist/have the same state
+	check_contents(m2, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(CopyAssignment){
+	TestMap m1({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	TestMap m2;
+	m2=m1;
+	ENSURE(m1==m2);
+	m1.clear(); //m2 must in no way depend on m1 continuing to exist/have the same state
+	check_contents(m2, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(MoveAssignment){
+	TestMap m1({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	TestMap m2;
+	m2=std::move(m1);
+	m1.clear(); //m2 must in no way depend on m1 continuing to exist/have the same state
+	check_contents(m2, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
 }
 
 TEST(PointerCopyConstruction){

--- a/core/tests/OrderedMapTest.cxx
+++ b/core/tests/OrderedMapTest.cxx
@@ -1,0 +1,918 @@
+#include <G3Test.h>
+
+#include <memory>
+#include <type_traits>
+
+#include <core/containers.h>
+
+TEST_GROUP(OrderedMap)
+
+using TestMap=OrderedMap<std::string,std::shared_ptr<std::string>>;
+using TestPairType=std::pair<std::string,std::shared_ptr<std::string>>;
+using TestValueType=std::pair<const std::string,std::shared_ptr<std::string>>;
+
+static_assert(std::is_default_constructible<TestMap>::value,
+              "OrderedMap must be default constructible");
+
+static_assert(std::is_constructible<TestMap, std::size_t>::value,
+              "OrderedMap must be constructible from a number of hash buckets");
+
+static_assert(std::is_constructible<TestMap, std::size_t, std::hash<std::string>>::value,
+              "OrderedMap must be constructible from a number of hash buckets and a hasher");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a hasher, "
+              "and a key comprator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a hasher, "
+              "a key comprator, and a data allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a hasher, "
+              "a key comprator, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators and a number of hash buckets");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t, std::hash<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, a number of hash buckets, "
+              "and a hasher");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, a number of hash buckets, "
+              "a hasher, and a comparator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, a number of hash buckets, "
+              "a hasher, a comparator, and a data allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, a number of hash buckets, "
+              "a hasher, a comparator, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list and a number of hash buckets");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t, std::hash<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, a number of hash buckets, "
+              "and a hasher");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, a number of hash buckets, "
+              "a hasher, and a comparator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, a number of hash buckets, "
+              "a hasher, a comparator, and a data allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t, std::hash<std::string>, std::equal_to<std::string>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, a number of hash buckets, "
+              "a hasher, a comparator, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a data allocator");
+
+static_assert(std::is_constructible<TestMap, 
+                                    std::allocator<std::pair<const std::string, 
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a data allocator and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    TestMap&,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a reference to another map and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    TestMap&,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a reference to another map, a data allocator, "
+              "and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a data allocator, "
+              "and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::size_t,
+                                    std::hash<std::string>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets and a hasher");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a hasher, "
+              "and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a number of hash buckets, a hasher, "
+              "a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, "
+              "a number of hash buckets, and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, "
+              "a number of hash buckets, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, "
+              "a number of hash buckets, a hasher, and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::list<TestPairType>::iterator, std::list<TestPairType>::iterator,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from a pair of data iterators, "
+              "a number of hash buckets, a hasher, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, "
+              "a number of hash buckets, and a data allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, "
+              "a number of hash buckets, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>,
+                                    std::allocator<std::pair<const std::string, 
+                                                             typename std::list<std::pair<const std::string, std::shared_ptr<std::string>>>::iterator>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, "
+              "a number of hash buckets, a hasher, a data allocator, and an index allocator");
+
+static_assert(std::is_constructible<TestMap,
+                                    std::initializer_list<TestValueType>,
+                                    std::size_t,
+                                    std::hash<std::string>,
+                                    std::allocator<std::pair<const std::string,
+                                                             std::shared_ptr<std::string>>>
+                                   >::value,
+              "OrderedMap must be constructible from an initializer list, "
+              "a number of hash buckets, a hasher, and a data allocator");
+
+static_assert(std::is_copy_constructible<TestMap>::value,
+              "OrderedMap must be copy constructible");
+
+static_assert(std::is_move_constructible<TestMap>::value,
+              "OrderedMap must be move constructible");
+
+static_assert(std::is_copy_assignable<TestMap>::value,
+              "OrderedMap must be copy assignable");
+
+static_assert(std::is_move_assignable<TestMap>::value,
+              "OrderedMap must be move assignable");
+
+static_assert(std::is_assignable<TestMap, std::initializer_list<TestValueType>>::value,
+              "OrderedMap must be assignable from an initializer list");
+
+void check_contents(const TestMap& map, const std::initializer_list<std::pair<std::string,std::string>>& exp){
+	ENSURE_EQUAL(map.size(), exp.size());
+	//check via iteration interface
+	auto mit=map.begin();
+	for(auto eit=exp.begin(), end=exp.end(); eit!=end; mit++,eit++){
+		ENSURE_EQUAL(mit->first, eit->first, "Keys must match");
+		ENSURE_EQUAL(*mit->second, eit->second, "Values must match");
+	}
+	//check via lookup interface
+	for(auto eit=exp.begin(), end=exp.end(); eit!=end; mit++,eit++){
+		auto mit=map.find(eit->first);
+		ENSURE(mit!=map.end());
+		ENSURE_EQUAL(mit->first, eit->first, "Keys must match");
+		ENSURE_EQUAL(*mit->second, eit->second, "Values must match");
+	}
+}
+
+TEST(IteratorRangeConstruction){
+	std::list<TestPairType> raw={{"foo",std::make_shared<std::string>("bar")},
+	                             {"baz",std::make_shared<std::string>("quux")},
+	                             {"xen",std::make_shared<std::string>("hom")}};
+	TestMap map(raw.begin(), raw.end());
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InitializerListConstruction){
+	std::list<TestPairType> raw={{"foo",std::make_shared<std::string>("bar")},
+	                             {"baz",std::make_shared<std::string>("quux")},
+	                             {"xen",std::make_shared<std::string>("hom")}};
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InitializerListAssignement){
+	std::initializer_list<TestValueType> il{{"foo",std::make_shared<std::string>("bar")},
+	                                        {"baz",std::make_shared<std::string>("quux")},
+	                                        {"xen",std::make_shared<std::string>("hom")}};
+	TestMap map({{"drel",std::make_shared<std::string>("plugh")}});
+	map = il;
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(Emplace){
+	TestMap map;
+	
+	auto res=map.emplace("foo", std::make_shared<std::string>("bar"));
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"}});
+	res=map.emplace(std::make_pair("baz", std::make_shared<std::string>("quux")));
+	ENSURE_EQUAL(res.first->first, "baz");
+	ENSURE_EQUAL(*res.first->second, "quux");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	res=map.emplace(std::piecewise_construct, 
+	                std::make_tuple("xen"), 
+	                std::make_tuple(std::make_shared<std::string>("hom")));
+	ENSURE_EQUAL(res.first->first, "xen");
+	ENSURE_EQUAL(*res.first->second, "hom");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	res=map.emplace("foo", std::make_shared<std::string>("drel"));
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, false);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(EmplaceHint){
+	TestMap map;
+	
+	auto res=map.emplace_hint(map.begin(), "foo", std::make_shared<std::string>("bar"));
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"}});
+	res=map.emplace_hint(map.begin(), std::make_pair("baz", std::make_shared<std::string>("quux")));
+	ENSURE_EQUAL(res->first, "baz");
+	ENSURE_EQUAL(*res->second, "quux");
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	res=map.emplace_hint(map.begin(), std::piecewise_construct, 
+	                     std::make_tuple("xen"), 
+	                     std::make_tuple(std::make_shared<std::string>("hom")));
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	res=map.emplace_hint(map.begin(), "foo", std::make_shared<std::string>("drel"));
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertRef){
+	TestMap map;
+	
+	TestValueType p0("foo", std::make_shared<std::string>("bar"));
+	auto res=map.insert((const TestValueType&)p0);
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"}});
+	TestValueType p1("baz", std::make_shared<std::string>("quux"));
+	res=map.insert((const TestValueType&)p1);
+	ENSURE_EQUAL(res.first->first, "baz");
+	ENSURE_EQUAL(*res.first->second, "quux");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	TestValueType p2("xen", std::make_shared<std::string>("hom"));
+	res=map.insert((const TestValueType&)p2);
+	ENSURE_EQUAL(res.first->first, "xen");
+	ENSURE_EQUAL(*res.first->second, "hom");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	TestValueType p3("foo", std::make_shared<std::string>("drel"));
+	res=map.insert((const TestValueType&)p3);
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, false);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertRRef){
+	TestMap map;
+	
+	TestValueType p0("foo", std::make_shared<std::string>("bar"));
+	auto res=map.insert(std::move(p0));
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"}});
+	TestValueType p1("baz", std::make_shared<std::string>("quux"));
+	res=map.insert(std::move(p1));
+	ENSURE_EQUAL(res.first->first, "baz");
+	ENSURE_EQUAL(*res.first->second, "quux");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	TestValueType p2("xen", std::make_shared<std::string>("hom"));
+	res=map.insert(std::move(p2));
+	ENSURE_EQUAL(res.first->first, "xen");
+	ENSURE_EQUAL(*res.first->second, "hom");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	TestValueType p3("foo", std::make_shared<std::string>("drel"));
+	res=map.insert(std::move(p3));
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, false);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertConvertible){
+	struct Thing{
+		std::string k;
+		std::shared_ptr<std::string> v;
+		Thing(const std::string& k, const std::string& v):
+		k(k),v(std::make_shared<std::string>(v)){}
+		operator TestValueType() const{
+			return TestValueType(k,v);
+		}
+	};
+	TestMap map;
+	
+	Thing p0("foo", "bar");
+	auto res=map.insert(p0);
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"}});
+	Thing p1("baz", "quux");
+	res=map.insert(p1);
+	ENSURE_EQUAL(res.first->first, "baz");
+	ENSURE_EQUAL(*res.first->second, "quux");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	Thing p2("xen", "hom");
+	res=map.insert(p2);
+	ENSURE_EQUAL(res.first->first, "xen");
+	ENSURE_EQUAL(*res.first->second, "hom");
+	ENSURE_EQUAL(res.second, true);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	Thing p3("foo", "drel");
+	res=map.insert(p3);
+	ENSURE_EQUAL(res.first->first, "foo");
+	ENSURE_EQUAL(*res.first->second, "bar");
+	ENSURE_EQUAL(res.second, false);
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertHintRef){
+	TestMap map;
+	
+	TestValueType p0("foo", std::make_shared<std::string>("bar"));
+	auto res=map.insert(map.begin(), (const TestValueType&)p0);
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"}});
+	TestValueType p1("baz", std::make_shared<std::string>("quux"));
+	res=map.insert(map.begin(), (const TestValueType&)p1);
+	ENSURE_EQUAL(res->first, "baz");
+	ENSURE_EQUAL(*res->second, "quux");
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	TestValueType p2("xen", std::make_shared<std::string>("hom"));
+	res=map.insert(map.begin(), (const TestValueType&)p2);
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	TestValueType p3("foo", std::make_shared<std::string>("drel"));
+	res=map.insert(map.begin(), (const TestValueType&)p3);
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertHintRRef){
+	TestMap map;
+	
+	TestValueType p0("foo", std::make_shared<std::string>("bar"));
+	auto res=map.insert(map.begin(), std::move(p0));
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"}});
+	TestValueType p1("baz", std::make_shared<std::string>("quux"));
+	res=map.insert(map.begin(), std::move(p1));
+	ENSURE_EQUAL(res->first, "baz");
+	ENSURE_EQUAL(*res->second, "quux");
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	TestValueType p2("xen", std::make_shared<std::string>("hom"));
+	res=map.insert(map.begin(), std::move(p2));
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	TestValueType p3("foo", std::make_shared<std::string>("drel"));
+	res=map.insert(map.begin(), std::move(p3));
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertHintConvertible){
+	struct Thing{
+		std::string k;
+		std::shared_ptr<std::string> v;
+		Thing(const std::string& k, const std::string& v):
+		k(k),v(std::make_shared<std::string>(v)){}
+		operator TestValueType() const{
+			return TestValueType(k,v);
+		}
+	};
+	TestMap map;
+	
+	Thing p0("foo", "bar");
+	auto res=map.insert(map.begin(), p0);
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"}});
+	Thing p1("baz", "quux");
+	res=map.insert(map.begin(), p1);
+	ENSURE_EQUAL(res->first, "baz");
+	ENSURE_EQUAL(*res->second, "quux");
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	Thing p2("xen", "hom");
+	res=map.insert(map.begin(), p2);
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+	
+	//atempting to emplace with an existing key should do nothing
+	Thing p3("foo", "drel");
+	res=map.insert(map.begin(), p3);
+	ENSURE_EQUAL(res->first, "foo");
+	ENSURE_EQUAL(*res->second, "bar");
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertIteratorRange){
+	std::list<TestPairType> raw={{"foo",std::make_shared<std::string>("bar")},
+	                             {"baz",std::make_shared<std::string>("quux")},
+	                             {"xen",std::make_shared<std::string>("hom")}};
+	TestMap map;
+	map.insert(raw.begin(), raw.end());
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(InsertInitializerList){
+	std::list<TestValueType> raw={{"foo",std::make_shared<std::string>("bar")},
+	                              {"baz",std::make_shared<std::string>("quux")},
+	                              {"xen",std::make_shared<std::string>("hom")}};
+	TestMap map;
+	map.insert({{"foo",std::make_shared<std::string>("bar")},
+	            {"baz",std::make_shared<std::string>("quux")},
+	            {"xen",std::make_shared<std::string>("hom")}});
+	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
+TEST(EraseIterator){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto res=map.erase(map.find("baz"));
+	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"xen","hom"}});
+	
+	res=map.erase(map.find("xen"));
+	ENSURE_EQUAL(map.size(), 1);
+	ENSURE(res==map.end());
+	check_contents(map, {{"foo","bar"}});
+	
+	res=map.erase(map.find("foo"));
+	ENSURE_EQUAL(map.size(), 0);
+	ENSURE(res==map.end());
+}
+
+TEST(EraseConstIterator){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto res=map.erase((TestMap::const_iterator)map.find("baz"));
+	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"foo","bar"},{"xen","hom"}});
+	
+	res=map.erase((TestMap::const_iterator)map.find("xen"));
+	ENSURE_EQUAL(map.size(), 1);
+	ENSURE(res==map.end());
+	check_contents(map, {{"foo","bar"}});
+	
+	res=map.erase((TestMap::const_iterator)map.find("foo"));
+	ENSURE_EQUAL(map.size(), 0);
+	ENSURE(res==map.end());
+}
+
+TEST(EraseKey){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto res=map.erase("baz");
+	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(res, 1);
+	check_contents(map, {{"foo","bar"},{"xen","hom"}});
+	
+	res=map.erase("drel");
+	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(res, 0);
+	check_contents(map, {{"foo","bar"},{"xen","hom"}});
+	
+	res=map.erase("xen");
+	ENSURE_EQUAL(map.size(), 1);
+	ENSURE_EQUAL(res, 1);
+	check_contents(map, {{"foo","bar"}});
+	
+	res=map.erase("foo");
+	ENSURE_EQUAL(map.size(), 0);
+	ENSURE_EQUAL(res, 1);
+}
+
+TEST(EraseIteratorRange){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto res=map.erase(map.begin(), map.find("xen"));
+	ENSURE_EQUAL(res->first, "xen");
+	ENSURE_EQUAL(*res->second, "hom");
+	check_contents(map, {{"xen","hom"}});
+	res=map.erase(map.begin(), map.end());
+	ENSURE(res==map.end());
+	ENSURE(map.empty());
+}
+
+TEST(Swap){
+	TestMap m1({{"foo",std::make_shared<std::string>("bar")},
+	            {"baz",std::make_shared<std::string>("quux")}});
+	TestMap m2({{"xen",std::make_shared<std::string>("hom")},
+	            {"drel",std::make_shared<std::string>("plugh")}});
+	m1.swap(m2);
+	check_contents(m2, {{"foo","bar"},{"baz","quux"}});
+	check_contents(m1, {{"xen","hom"},{"drel","plugh"}});
+}
+
+TEST(Find){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](std::string k, std::string v){
+		auto it=map.find(k);
+		ENSURE(it!=map.end());
+		ENSURE_EQUAL(it->first, k);
+		ENSURE_EQUAL(*it->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	ENSURE(map.find("drel")==map.end());
+}
+
+TEST(FindConst){
+	const TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	                   {"baz",std::make_shared<std::string>("quux")},
+	                   {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](std::string k, std::string v){
+		auto it=map.find(k);
+		ENSURE(it!=map.end());
+		ENSURE_EQUAL(it->first, k);
+		ENSURE_EQUAL(*it->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	ENSURE(map.find("drel")==map.end());
+}
+
+namespace convertible_key{
+	struct Key{
+		std::string s;
+		Key(const char* d):s(d){}
+		operator std::string() const{ return s; }
+	};
+	bool operator==(const std::string& s, const Key& t){ return s==t.s; }
+	std::ostream& operator<<(std::ostream& os, const Key& t){
+		return os << "Key(" << t.s << ')';
+	}
+}
+
+TEST(FindConvertible){
+	using namespace convertible_key;
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](const Key& k, std::string v){
+		auto it=map.find(k);
+		ENSURE(it!=map.end());
+		ENSURE_EQUAL(it->first, k);
+		ENSURE_EQUAL(*it->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	ENSURE(map.find("drel")==map.end());
+}
+
+TEST(FindConstConvertible){
+	using namespace convertible_key;
+	const TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	                   {"baz",std::make_shared<std::string>("quux")},
+	                   {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](const Key& k, std::string v){
+		auto it=map.find(k);
+		ENSURE(it!=map.end());
+		ENSURE_EQUAL(it->first, k);
+		ENSURE_EQUAL(*it->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	ENSURE(map.find("drel")==map.end());
+}
+
+TEST(EqualRange){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](std::string k, std::string v){
+		auto r=map.equal_range(k);
+		ENSURE(r.first!=map.end());
+		ENSURE_EQUAL(std::distance(r.first,r.second),1,
+		             "With unique keys equal_range should never return ranges longer than 1");
+		ENSURE_EQUAL(r.first->first, k);
+		ENSURE_EQUAL(*r.first->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	{
+		auto r=map.equal_range(std::string("drel"));
+		ENSURE(r.first==map.end());
+		ENSURE(r.second==map.end());
+	}
+}
+
+TEST(EqualRangeConst){
+	const TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	                   {"baz",std::make_shared<std::string>("quux")},
+	                   {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](std::string k, std::string v){
+		auto r=map.equal_range(k);
+		ENSURE(r.first!=map.end());
+		ENSURE_EQUAL(std::distance(r.first,r.second),1,
+		             "With unique keys equal_range should never return ranges longer than 1");
+		ENSURE_EQUAL(r.first->first, k);
+		ENSURE_EQUAL(*r.first->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	{
+		auto r=map.equal_range(std::string("drel"));
+		ENSURE(r.first==map.end());
+		ENSURE(r.second==map.end());
+	}
+}
+
+TEST(EqualRangeConvertible){
+	using namespace convertible_key;
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](Key k, std::string v){
+		auto r=map.equal_range(k);
+		ENSURE(r.first!=map.end());
+		ENSURE_EQUAL(std::distance(r.first,r.second),1,
+		             "With unique keys equal_range should never return ranges longer than 1");
+		ENSURE_EQUAL(r.first->first, k);
+		ENSURE_EQUAL(*r.first->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	{
+		auto r=map.equal_range(Key("drel"));
+		ENSURE(r.first==map.end());
+		ENSURE(r.second==map.end());
+	}
+}
+
+TEST(EqualRangeConvertibleConst){
+	using namespace convertible_key;
+	const TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	                   {"baz",std::make_shared<std::string>("quux")},
+	                   {"xen",std::make_shared<std::string>("hom")}});
+	auto check_found=[&](Key k, std::string v){
+		auto r=map.equal_range(k);
+		ENSURE(r.first!=map.end());
+		ENSURE_EQUAL(std::distance(r.first,r.second),1,
+		             "With unique keys equal_range should never return ranges longer than 1");
+		ENSURE_EQUAL(r.first->first, k);
+		ENSURE_EQUAL(*r.first->second, v);
+	};
+	check_found("foo","bar");
+	check_found("baz","quux");
+	check_found("xen","hom");
+	{
+		auto r=map.equal_range(Key("drel"));
+		ENSURE(r.first==map.end());
+		ENSURE(r.second==map.end());
+	}
+}
+
+TEST(Indexing){
+	TestMap map;
+	map["foo"]=std::make_shared<std::string>("bar");
+	check_contents(map, {{"foo","bar"}});
+	ENSURE_EQUAL(*map["foo"], "bar");
+	map["baz"]=std::make_shared<std::string>("quux");
+	check_contents(map, {{"foo","bar"},{"baz","quux"}});
+	ENSURE_EQUAL(*map["baz"], "quux");
+	map["foo"]=std::make_shared<std::string>("xen");
+	check_contents(map, {{"foo","xen"},{"baz","quux"}});
+	ENSURE_EQUAL(*map["foo"], "xen");
+}
+
+TEST(At){
+	TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	             {"baz",std::make_shared<std::string>("quux")},
+	             {"xen",std::make_shared<std::string>("hom")}});
+	ENSURE_EQUAL(*map.at("foo"), "bar");
+	ENSURE_EQUAL(*map.at("baz"), "quux");
+	ENSURE_EQUAL(*map.at("xen"), "hom");
+	try{
+		map.at("drel");
+		FAIL("std::out_of_range should be thrown");
+	}
+	catch(std::out_of_range& ex){
+		//expected
+	}
+}
+
+TEST(AtConst){
+	const TestMap map({{"foo",std::make_shared<std::string>("bar")},
+	                   {"baz",std::make_shared<std::string>("quux")},
+	                   {"xen",std::make_shared<std::string>("hom")}});
+	ENSURE_EQUAL(*map.at("foo"), "bar");
+	ENSURE_EQUAL(*map.at("baz"), "quux");
+	ENSURE_EQUAL(*map.at("xen"), "hom");
+	try{
+		map.at("drel");
+		FAIL("std::out_of_range should be thrown");
+	}
+	catch(std::out_of_range& ex){
+		//expected
+	}
+}

--- a/core/tests/OrderedMapTest.cxx
+++ b/core/tests/OrderedMapTest.cxx
@@ -663,22 +663,22 @@ TEST(EraseKey){
 	             {"xen",std::make_shared<std::string>("hom")}});
 	auto res=map.erase("baz");
 	ENSURE_EQUAL(map.size(), 2U);
-	ENSURE_EQUAL(res, 1);
+	ENSURE_EQUAL(res, 1U);
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase("drel");
 	ENSURE_EQUAL(map.size(), 2U);
-	ENSURE_EQUAL(res, 0);
+	ENSURE_EQUAL(res, 0U);
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase("xen");
 	ENSURE_EQUAL(map.size(), 1U);
-	ENSURE_EQUAL(res, 1);
+	ENSURE_EQUAL(res, 1U);
 	check_contents(map, {{"foo","bar"}});
 	
 	res=map.erase("foo");
 	ENSURE_EQUAL(map.size(), 0U);
-	ENSURE_EQUAL(res, 1);
+	ENSURE_EQUAL(res, 1U);
 }
 
 TEST(EraseIteratorRange){

--- a/core/tests/OrderedMapTest.cxx
+++ b/core/tests/OrderedMapTest.cxx
@@ -351,6 +351,18 @@ TEST(InitializerListAssignement){
 	check_contents(map, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
 }
 
+TEST(PointerCopyConstruction){
+	std::shared_ptr<TestMap> ptr;
+	{
+		std::list<TestPairType> raw={{"foo",std::make_shared<std::string>("bar")},
+		                             {"baz",std::make_shared<std::string>("quux")},
+		                             {"xen",std::make_shared<std::string>("hom")}};
+		TestMap map(raw.begin(), raw.end());
+		ptr = std::make_shared<TestMap>(map);
+	}
+	check_contents(*ptr, {{"foo","bar"},{"baz","quux"},{"xen","hom"}});
+}
+
 TEST(Emplace){
 	TestMap map;
 	

--- a/core/tests/OrderedMapTest.cxx
+++ b/core/tests/OrderedMapTest.cxx
@@ -622,18 +622,18 @@ TEST(EraseIterator){
 	             {"baz",std::make_shared<std::string>("quux")},
 	             {"xen",std::make_shared<std::string>("hom")}});
 	auto res=map.erase(map.find("baz"));
-	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(map.size(), 2U);
 	ENSURE_EQUAL(res->first, "xen");
 	ENSURE_EQUAL(*res->second, "hom");
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase(map.find("xen"));
-	ENSURE_EQUAL(map.size(), 1);
+	ENSURE_EQUAL(map.size(), 1U);
 	ENSURE(res==map.end());
 	check_contents(map, {{"foo","bar"}});
 	
 	res=map.erase(map.find("foo"));
-	ENSURE_EQUAL(map.size(), 0);
+	ENSURE_EQUAL(map.size(), 0U);
 	ENSURE(res==map.end());
 }
 
@@ -642,18 +642,18 @@ TEST(EraseConstIterator){
 	             {"baz",std::make_shared<std::string>("quux")},
 	             {"xen",std::make_shared<std::string>("hom")}});
 	auto res=map.erase((TestMap::const_iterator)map.find("baz"));
-	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(map.size(), 2U);
 	ENSURE_EQUAL(res->first, "xen");
 	ENSURE_EQUAL(*res->second, "hom");
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase((TestMap::const_iterator)map.find("xen"));
-	ENSURE_EQUAL(map.size(), 1);
+	ENSURE_EQUAL(map.size(), 1U);
 	ENSURE(res==map.end());
 	check_contents(map, {{"foo","bar"}});
 	
 	res=map.erase((TestMap::const_iterator)map.find("foo"));
-	ENSURE_EQUAL(map.size(), 0);
+	ENSURE_EQUAL(map.size(), 0U);
 	ENSURE(res==map.end());
 }
 
@@ -662,22 +662,22 @@ TEST(EraseKey){
 	             {"baz",std::make_shared<std::string>("quux")},
 	             {"xen",std::make_shared<std::string>("hom")}});
 	auto res=map.erase("baz");
-	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(map.size(), 2U);
 	ENSURE_EQUAL(res, 1);
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase("drel");
-	ENSURE_EQUAL(map.size(), 2);
+	ENSURE_EQUAL(map.size(), 2U);
 	ENSURE_EQUAL(res, 0);
 	check_contents(map, {{"foo","bar"},{"xen","hom"}});
 	
 	res=map.erase("xen");
-	ENSURE_EQUAL(map.size(), 1);
+	ENSURE_EQUAL(map.size(), 1U);
 	ENSURE_EQUAL(res, 1);
 	check_contents(map, {{"foo","bar"}});
 	
 	res=map.erase("foo");
-	ENSURE_EQUAL(map.size(), 0);
+	ENSURE_EQUAL(map.size(), 0U);
 	ENSURE_EQUAL(res, 1);
 }
 

--- a/core/tests/timestream_2d.py
+++ b/core/tests/timestream_2d.py
@@ -9,7 +9,8 @@ from spt3g import core
 tsm = core.G3TimestreamMap()
 start = core.G3Time.Now()
 stop = start + 5*core.G3Units.s
-for ts in ['A', 'B', 'C', 'D']:
+keys = ['D', 'A', 'B', 'C']
+for ts in keys:
 	i = core.G3Timestream(numpy.random.normal(size=600))
 	i.start = start
 	i.stop = stop
@@ -20,6 +21,7 @@ buffer1d = numpy.asarray(list(tsm.values()))
 
 buffer2d = numpy.asarray(tsm)
 
+assert((numpy.asarray(keys) == numpy.asarray(tsm.keys())).all())
 assert(buffer1d.shape == buffer2d.shape)
 assert(buffer2d.shape == (4,600))
 assert((buffer1d == buffer2d).all())
@@ -45,7 +47,7 @@ assert(numpy.asarray(tsm2)[1,5] == 16)
 
 # And that writes propagate back to the underlying G3Timestream
 buffer2d[1] = numpy.random.normal(size=600)
-assert((numpy.asarray(tsm['B']) == buffer2d[1]).all())
+assert((numpy.asarray(tsm['B']) == buffer2d[keys.index('B')]).all())
 
 # Test initialization from numpy and data copying/sharing
 buffer1d[2,6] = -3.0


### PR DESCRIPTION
Use a custom OrderedMap class that behaves identically to std::map, except that items are iterated over in the order they were inserted into the map.

This allows preserving the detector ordering when creating a G3TimestreamMap from a 2D array and a set of keys, e.g. when converting between G3SuperTimestream and G3TimestreamMap objects, as the former are not guaranteed to be ordered alphabetically.

Performance is significantly faster than the standard std::map implementation, and maintains the same G3TimestreamMap serialization version.