### PR TITLE
Fix ang_to_quat missing return statement

### DIFF
--- a/maps/python/quathelpers.py
+++ b/maps/python/quathelpers.py
@@ -60,6 +60,7 @@ def ang_to_quat(alpha, delta, start=None, stop=None):
             out = G3TimestreamQuat(q)
             out.start = start
             out.stop = stop
+            return out
         else:
             return G3VectorQuat(q)
 

--- a/maps/tests/quatangtest.py
+++ b/maps/tests/quatangtest.py
@@ -20,3 +20,8 @@ assert(np.allclose(maps.ang_to_quat(alpha, delta), core.G3VectorQuat([maps.c_ang
 
 assert(np.allclose(maps.quat_to_ang(maps.c_ang_to_quat_(angle[0], angle[1])), angle))
 
+start = core.G3Time(0)
+stop = core.G3Time(10)
+q_timestream = maps.ang_to_quat(alpha, delta, start, stop)
+assert q_timestream.start == start
+assert q_timestream.stop == stop


### PR DESCRIPTION
Resolves #195.

- Fix `ang_to_quat` by adding the missing return statement.
- Add a simple test for `ang_to_quat` using the `start` and `stop` arguments.

This is my first contribution so please let me know if any changes are needed.