### PR TITLE
Memory-efficient variance for G3TimestreamMap objects

### DIFF
--- a/core/python/timestreamextensions.py
+++ b/core/python/timestreamextensions.py
@@ -142,7 +142,7 @@ for op in ["std", "var"]:
             bound_args = {}
             if op in ["std", "var"]:
                 bound_args["ddof"] = kwargs.pop("ddof", 0)
-            if not len(kwargs) and axis == -1 or axis == 1:
+            if not len(kwargs) and (axis == -1 or axis == 1):
                 ret = numpy.asarray(getattr(a, "_c" + op)(**bound_args))
                 if out is not None:
                     out[:] = ret

--- a/core/src/G3Timestream.cxx
+++ b/core/src/G3Timestream.cxx
@@ -1107,6 +1107,39 @@ G3TimestreamMap_times(const G3TimestreamMap &a)
 	return G3Timestream_times(*a.begin()->second);
 }
 
+double
+G3Timestream_var(const G3Timestream &ts, size_t ddof)
+{
+	double v1 = 0, v2 = 0;
+	for (size_t i = 0; i < ts.size(); i++) {
+		double v = ts[i];
+		v1 += v;
+		v2 += v * v;
+	}
+
+	return (v2 - v1 * v1 / (double) ts.size()) / (double)(ts.size() - ddof);
+}
+
+std::vector<double>
+G3TimestreamMap_var(const G3TimestreamMap &tsm, size_t ddof)
+{
+	std::vector<double> v;
+	v.reserve(tsm.size());
+	for (auto it: tsm)
+		v.push_back(G3Timestream_var(*it.second, ddof));
+	return v;
+}
+
+std::vector<double>
+G3TimestreamMap_std(const G3TimestreamMap &tsm, size_t ddof)
+{
+	std::vector<double> v;
+	v.reserve(tsm.size());
+	for (auto it: tsm)
+		v.push_back(sqrt(G3Timestream_var(*it.second, ddof)));
+	return v;
+}
+
 
 class G3Timestream::G3TimestreamPythonHelpers
 {
@@ -1616,6 +1649,8 @@ PYBINDINGS("core", scope) {
 	      "Compute elapsed time array for samples")
 	    .def_property_readonly("times", &G3TimestreamMap_times,
 	      "Compute time vector for samples")
+	    .def("_cvar", &G3TimestreamMap_var, py::arg("ddof")=0)
+	    .def("_cstd", &G3TimestreamMap_std, py::arg("ddof")=0)
 	;
 
 	// Add buffer protocol interface

--- a/core/tests/timestream_ops.py
+++ b/core/tests/timestream_ops.py
@@ -1,6 +1,7 @@
 import numpy as np
 from spt3g.core import (
     G3Timestream,
+    G3TimestreamMap,
     G3VectorDouble,
     DoubleVector,
     G3VectorInt,
@@ -163,3 +164,15 @@ for a in all_arr:
         "std",
     ]:
         assert getattr(a, attr)() == getattr(np, attr)(v1)
+
+    if isinstance(a, G3Timestream):
+        tsm = G3TimestreamMap(["a", "b", "c"], np.tile(v1, (3, 1)))
+
+        for attr in ["std", "var"]:
+            np.testing.assert_allclose(
+                getattr(tsm, attr)(axis=-1),
+                getattr(np, attr)(np.asarray(tsm), axis=-1),
+                atol=1e-14,
+                rtol=1e-14,
+                verbose=True,
+            )


### PR DESCRIPTION
The numpy ndarray var() implementation involves an array copy operation that doubles memory usage, which can drive the memory requirements for timestream processing.  This PR adds a var() implementation that avoids this copy operation for the relatively common case of efficiently computing the variance of each timestream in a G3TimestreamMap.  This code is called automatically when using the `numpy.var()` function over the last axis on a timestream map object.